### PR TITLE
chore: ignore .claude/ worktrees and session data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ jobs/*
 
 # Node.js dependencies
 **/node_modules/
+
+# Claude Code worktrees and session data
+.claude/


### PR DESCRIPTION
Adds `.claude/` worktrees and session data directories to `.gitignore` to prevent Claude Code session artifacts from being accidentally tracked.