### PR TITLE
chore: document and ignore .worktrees/ convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ jobs/*
 # Node.js dependencies
 **/node_modules/
 
+# Local Git worktrees used by code agents
+.worktrees/
+
 # Claude Code worktrees and session data
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,15 @@ complexity factors along three axes (Environment Complexity, Cognitive Demand, R
 The agent under evaluation is **OpenClaw**. Harbor orchestrates Docker containers, launches the
 OpenClaw agent inside each container, and verifies the result. LiveClawBench provides the tasks.
 
+## Local Worktrees
+
+When creating additional Git worktrees for agent-driven branch work, place them under
+`./.worktrees/<branch-name>` at the repository root.
+
+- Do not create worktrees under `./.claude/`
+- Keep `./.claude/` for Claude-specific local settings/session data only
+- Treat `./.worktrees/` as disposable local workspace state and keep it untracked
+
 ## Setup
 
 ### Quick Setup (recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ line-length = 88
 
 exclude = [
     ".venv",
+    ".worktrees",
     ".claude",
     # Task fixture files: intentionally varied/broken content for agent tasks
     "tasks/skill-dependency-fix/environment/skills",


### PR DESCRIPTION
## Summary

- Add `.worktrees/` to `.gitignore` so agent-driven branch worktrees are never tracked
- Document the placement convention in `CLAUDE.md` (new *Local Worktrees* section): worktrees go under `./.worktrees/<branch-name>`, not under `.claude/`
- Exclude `.worktrees` from ruff linting scope in `pyproject.toml`

## Test plan

- [ ] Verify `git check-ignore -v .worktrees` returns a match after merge
- [ ] Verify `python scripts/validate_tasks.py` passes (no ruff scope regression)