### PR TITLE
docs: add dataset run guide and metrics collection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Step-by-step operational documentation for running and contributing to the bench
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](guide/getting-started.md) | Prerequisites, `setup.sh`, `.env` configuration, smoke test |
-| [Running Tasks](guide/running-tasks.md) | Harbor CLI flags, API key injection, results, full dataset runs |
+| [Running Tasks](guide/running-tasks.md) | Harbor CLI flags, API key injection, **`--dataset` with `--registry-path`**, per-task loop, results, metrics collection |
 | [Adding Tasks](guide/adding-tasks.md) | Task format, scoring contract, validation, submission checklist |
 
 ## Reference

--- a/docs/guide/running-tasks.md
+++ b/docs/guide/running-tasks.md
@@ -140,19 +140,22 @@ After a run completes, Harbor writes output to the directory specified with `-o`
 
 ```
 jobs/
-└── <job-id>/
-    └── <trial-id>/
-        └── logs/
-            ├── verifier/
-            │   └── reward.txt        # Final score: 0.0, 0.5, or 1.0
-            └── agent/
-                └── openclaw.txt      # Full agent session log
+└── <job-id>/                          # timestamp, e.g. 2026-03-29__21-11-23
+    ├── config.json                    # job-level config snapshot
+    ├── result.json                    # aggregated reward distribution
+    └── <task-name>__<random>/         # one subdirectory per trial
+        ├── verifier/
+        │   ├── reward.txt             # scalar score (0.0–1.0)
+        │   └── test-stdout.txt        # verifier stdout/stderr
+        └── agent/
+            ├── openclaw.txt           # full agent session log
+            └── trajectory.json        # ATIF structured trajectory
 ```
 
 Check all scores at once:
 
 ```bash
-cat jobs/*/logs/verifier/reward.txt
+find jobs -name reward.txt | sort | xargs -I{} sh -c 'echo "{}: $(cat {})"'
 ```
 
 | Score | Meaning |
@@ -173,19 +176,102 @@ harbor run -p tasks/flight-seat-selection -a openclaw \
 
 ## Running the Full Dataset
 
-To evaluate against all 29 tasks defined in `registry.json`:
+LiveClawBench registers its 30 tasks as a dataset named `liveclawbench@1.0` in the local `registry.json`.
+
+### Option 1: Local registry (recommended for development)
 
 ```bash
 harbor run --dataset liveclawbench@1.0 \
+  --registry-path ./registry.json \
   -a openclaw \
   -m custom/<YOUR_MODEL_ID> \
   --n-concurrent 4 \
   -o jobs \
   --ae CUSTOM_BASE_URL="<YOUR_BASE_URL>" \
-  --ae CUSTOM_API_KEY="<YOUR_API_KEY>"
+  --ae CUSTOM_API_KEY="<YOUR_API_KEY>" \
+  --ee JUDGE_BASE_URL="<YOUR_JUDGE_BASE_URL>" \
+  --ee JUDGE_API_KEY="<YOUR_JUDGE_API_KEY>" \
+  --ee JUDGE_MODEL_ID="deepseek-v3.2"
 ```
 
-`--n-concurrent` controls how many tasks run in parallel. Start low (2–4) to avoid resource exhaustion.
+> **Why `--registry-path`?** Harbor's `--dataset` flag by default fetches the registry from `github.com/laude-institute/harbor`. Since `liveclawbench` is only registered in the local `registry.json`, you must pass `--registry-path ./registry.json` to tell Harbor where to find the dataset definition.
+
+### Option 2: Per-task loop (alternative, avoids timestamp collisions)
+
+For running tasks in parallel without relying on Harbor's `--n-concurrent`, use a script that assigns each task its own output directory:
+
+```bash
+# See scripts/run_runnability_check.sh for a complete example
+for task in tasks/*/; do
+  harbor run -p "$task" -a openclaw \
+    -m custom/kimi-k2.5 \
+    -n 1 -o "jobs/$(basename $task)" \
+    --ae CUSTOM_BASE_URL=... --ae CUSTOM_API_KEY=... &
+done
+wait
+```
+
+This avoids the timestamp collision issue entirely because each `harbor run` writes to a distinct `jobs/<task-name>/` directory.
+
+> **Tip:** When using the per-task loop approach, remember to also pass `--ee JUDGE_*` variables for the 5 LLM-judge tasks. See [LLM-judge tasks](#llm-judge-tasks) for the full list and explanation.
+
+### Option 3: Use the provided script
+
+```bash
+bash scripts/run_dataset.sh
+```
+
+This script wraps the `--dataset` command with the correct `--registry-path`, judge credentials, and sensible defaults (`--n-concurrent 4`, `--timeout-multiplier 2.0`).
+
+## Collecting Metrics
+
+After a run (single task or full dataset), scores are in `reward.txt` files nested inside `jobs/`.
+
+### Quick score summary
+
+```bash
+# Print path : score for every completed trial
+find jobs -name reward.txt | sort | xargs -I{} sh -c 'echo "{}: $(cat {})"'
+```
+
+### Structured summary table (Python)
+
+```python
+import glob, os
+
+tasks = sorted(d for d in os.listdir("tasks") if os.path.isdir(f"tasks/{d}"))
+print(f"{'Task':<45} {'Score':>6}  Status")
+print("-" * 60)
+for task in tasks:
+    # For per-task loop output: jobs/<task-name>/*/verifier/reward.txt
+    # For dataset run output: jobs/<timestamp>/<task-name>__/verifier/reward.txt
+    files = sorted(glob.glob(f"jobs/**/{task}__*/verifier/reward.txt"))
+    if not files:
+        files = sorted(glob.glob(f"jobs/{task}/**/verifier/reward.txt"))
+    if files:
+        score_str = open(files[-1]).read().strip()
+        try:
+            score = float(score_str)
+            status = "✅" if score >= 0.5 else "❌"
+        except ValueError:
+            status = "⚠️ parse error"
+            score_str = "?"
+    else:
+        score_str, status = "missing", "⚠️ no result"
+    print(f"{task:<45} {score_str:>6}  {status}")
+```
+
+### What to check when a score is missing or unexpected
+
+| Symptom | Where to look |
+|---------|---------------|
+| `reward.txt` absent | `verifier/test-stdout.txt` — did the verifier run? `trial.log` — agent timeout? |
+| Score is 0.0 | `verifier/test-stdout.txt` — which assertion failed |
+| Agent never started | `agent/command-0/return-code.txt`, `agent/command-1/return-code.txt` |
+| Harbor-level crash | `<trial>/result.json` → `exception_info` field |
+| Multiple `reward.txt` files per task | Use `jobs/<task-name>/` structure (per-task loop) or pick the latest by timestamp |
+
+See [`docs/reference/jobs-output.md`](../reference/jobs-output.md) for the full directory layout and field reference.
 
 ## LLM-judge tasks
 
@@ -234,3 +320,37 @@ The judge model can be the same endpoint as the agent model or a different one. 
 - Use `--timeout-multiplier 2.0` for `hard` difficulty tasks; some may need `3.0`
 - `--debug` keeps the container alive after failure for manual inspection
 - Check `/tmp/*.log` files inside a failed container for service startup errors
+
+## Known Issues
+
+### Timestamp collision when running tasks concurrently
+
+Harbor names each job directory after the UTC second the run starts
+(e.g. `jobs/2026-03-29__21-11-23`). When multiple `harbor run -p tasks/<X>` commands
+fire in the same second — for example from a parallel shell loop — some processes
+may find the directory already created by another task and fail with:
+
+```
+FileExistsError: Job directory jobs/<timestamp> already exists and
+cannot be resumed with a different config.
+```
+
+**Resolution:** use a different `-o` directory for the retry run:
+
+```bash
+harbor run -p tasks/<task> ... -o jobs_retry
+```
+
+Or, if you are re-running a single task and the existing directory is stale, delete it first:
+
+```bash
+# ⚠ Only if you don't mind losing the prior result
+rm -rf jobs/<conflicting-timestamp>
+harbor run -p tasks/<task> ... -o jobs
+```
+
+To avoid the collision entirely when scripting parallel runs, use one of these approaches:
+
+1. **Per-task output directories** (`-o "jobs/<task-name>"`) — used by `scripts/run_runnability_check.sh`
+2. **`--dataset` with `--registry-path`** — harbor manages job directories internally (`scripts/run_dataset.sh`)
+3. Serialize task start-up with a short delay between launches

--- a/registry.json
+++ b/registry.json
@@ -2,13 +2,14 @@
   {
     "name": "liveclawbench",
     "version": "1.0",
-    "description": "LiveClawBench: Benchmarking LLM Agents on Complex, Real-World Assistant Tasks. 29 pilot cases with 4 complexity factors (A1/A2/B1/B2) across 7 task domains.",
+    "description": "LiveClawBench: Benchmarking LLM Agents on Complex, Real-World Assistant Tasks. 30 tasks with 4 complexity factors (A1/A2/B1/B2) across 7 task domains.",
     "tasks": [
       {"name": "skill-creation", "path": "tasks/skill-creation"},
       {"name": "skill-supplementation", "path": "tasks/skill-supplementation"},
       {"name": "skill-conflict-resolution", "path": "tasks/skill-conflict-resolution"},
       {"name": "skill-repository-curation", "path": "tasks/skill-repository-curation"},
       {"name": "skill-dependency-fix", "path": "tasks/skill-dependency-fix"},
+      {"name": "skill-combination", "path": "tasks/skill-combination"},
       {"name": "email-writing", "path": "tasks/email-writing"},
       {"name": "email-reply", "path": "tasks/email-reply"},
       {"name": "flight-booking", "path": "tasks/flight-booking"},

--- a/scripts/run_dataset.sh
+++ b/scripts/run_dataset.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 
 source .env
 
-harbor run --dataset liveclawbench@1.0 \
+.venv/bin/harbor run --dataset liveclawbench@1.0 \
   --registry-path ./registry.json \
   -a openclaw \
   -m custom/kimi-k2.5 \

--- a/scripts/run_dataset.sh
+++ b/scripts/run_dataset.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run all 30 LiveClawBench tasks using harbor --dataset with --registry-path
+# This avoids timestamp collision issues by letting harbor manage job directories internally.
+#
+# Usage: bash scripts/run_dataset.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+source .env
+
+harbor run --dataset liveclawbench@1.0 \
+  --registry-path ./registry.json \
+  -a openclaw \
+  -m custom/kimi-k2.5 \
+  --n-concurrent 4 \
+  --n-attempts 1 \
+  -o jobs \
+  --ae "CUSTOM_BASE_URL=$OPENAI_BASE_URL" \
+  --ae "CUSTOM_API_KEY=$OPENAI_API_KEY" \
+  --ee "JUDGE_BASE_URL=$OPENAI_BASE_URL" \
+  --ee "JUDGE_API_KEY=$OPENAI_API_KEY" \
+  --ee "JUDGE_MODEL_ID=deepseek-v3.2" \
+  --timeout-multiplier 2.0

--- a/scripts/run_runnability_check.sh
+++ b/scripts/run_runnability_check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Runnability check: run all 30 tasks with kimi-k2.5 (custom provider)
 # Usage: bash scripts/run_runnability_check.sh
-set -uo pipefail
+set -euo pipefail
 cd "$(dirname "$0")/.."
 
 source .env

--- a/scripts/run_runnability_check.sh
+++ b/scripts/run_runnability_check.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Runnability check: run all 30 tasks with kimi-k2.5 (custom provider)
+# Usage: bash scripts/run_runnability_check.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+source .env
+BASE_URL="$OPENAI_BASE_URL"
+API_KEY="$OPENAI_API_KEY"
+JUDGE_TASKS="noise-filtering mixed-tool-memory incremental-update-ctp live-web-research-sqlite-fts5 conflict-repair-acb"
+MAX_CONCURRENT=4
+
+mkdir -p run_logs
+pids=()
+task_names=()
+
+wait_for_slot() {
+    while [ "${#pids[@]}" -ge "$MAX_CONCURRENT" ]; do
+        new_pids=()
+        new_names=()
+        for i in "${!pids[@]}"; do
+            if kill -0 "${pids[$i]}" 2>/dev/null; then
+                new_pids+=("${pids[$i]}")
+                new_names+=("${task_names[$i]}")
+            fi
+        done
+        pids=("${new_pids[@]+"${new_pids[@]}"}")
+        task_names=("${new_names[@]+"${new_names[@]}"}")
+        [ "${#pids[@]}" -ge "$MAX_CONCURRENT" ] && sleep 5
+    done
+}
+
+for task_dir in tasks/*/; do
+    task=$(basename "$task_dir")
+
+    judge_flags=()
+    if echo "$JUDGE_TASKS" | grep -qw "$task"; then
+        judge_flags=(
+            --ee "JUDGE_BASE_URL=$BASE_URL"
+            --ee "JUDGE_API_KEY=$API_KEY"
+            --ee "JUDGE_MODEL_ID=deepseek-v3.2"
+        )
+    fi
+
+    wait_for_slot
+
+    echo "[$(date '+%H:%M:%S')] START: $task"
+    (
+        .venv/bin/harbor run -p "tasks/$task" -a openclaw \
+            -m custom/kimi-k2.5 \
+            -n 1 -o "jobs/${task}" \
+            --ae "CUSTOM_BASE_URL=$BASE_URL" \
+            --ae "CUSTOM_API_KEY=$API_KEY" \
+            "${judge_flags[@]+"${judge_flags[@]}"}" \
+            >"run_logs/${task}.log" 2>&1
+        code=$?
+        echo "[$(date '+%H:%M:%S')] DONE: $task (exit=$code)"
+    ) &
+    pids+=($!)
+    task_names+=("$task")
+done
+
+# Wait for remaining tasks
+wait
+echo "=== All tasks finished ==="
+
+# Print summary
+echo ""
+echo "=== Results Summary ==="
+printf "%-45s %s\n" "Task" "Score"
+printf "%-45s %s\n" "----" "-----"
+for task_dir in tasks/*/; do
+    task=$(basename "$task_dir")
+    reward=$(find "jobs/${task}" -name "reward.txt" 2>/dev/null | sort | tail -1 | xargs cat 2>/dev/null || echo "ERROR")
+    printf "%-45s %s\n" "$task" "$reward"
+done


### PR DESCRIPTION
## Summary

Documentation updates for running LiveClawBench tasks at scale, plus registry fix.

## Changes

### docs/guide/running-tasks.md

- **Fix**: Corrected jobs output directory structure (was showing incorrect paths)
- **New section**: 3 options for running the full dataset:
  1. `--dataset liveclawbench@1.0 --registry-path ./registry.json` (harbor-managed concurrency)
  2. Per-task loop with `-o "jobs/<task-name>"` (avoids timestamp collision)
  3. `scripts/run_dataset.sh` wrapper script
- **New section**: "Collecting Metrics" with:
  - One-liner `find` command for quick score summary
  - Python script for structured markdown table output
  - Troubleshooting table (where to look for common symptoms)
- **New section**: "Known Issues" documenting timestamp collision and 3 resolution approaches

### docs/README.md

- Updated Running Tasks description to reflect new content

### registry.json

- Added missing `skill-combination` task entry
- Updated description: "29 pilot cases" → "30 tasks"

### scripts/ (new)

- `run_dataset.sh`: Wrapper for `--dataset` runs with correct flags
- `run_runnability_check.sh`: Per-task parallel execution script

## Motivation

During the 30-task runnability check (2026-03-29), encountered `FileExistsError` timestamp collision when running tasks in parallel. This PR documents the root cause and provides both immediate workarounds and long-term solutions.

## Verification

```bash
# Test dataset run (single concurrent to verify syntax)
bash scripts/run_dataset.sh

# Test per-task loop
bash scripts/run_runnability_check.sh
```

Both scripts have been tested and successfully ran all 30 tasks.