### PR TITLE
docs(scripts): enable thinking mode for custom provider in evaluation scripts

### DIFF
--- a/docs/en/guide/running-tasks.md
+++ b/docs/en/guide/running-tasks.md
@@ -122,6 +122,8 @@ harbor run -p tasks/watch-shop -a openclaw \
   --ae CUSTOM_REASONING=true
 ```
 
+> **Auto-inference**: When `CUSTOM_REASONING=true`, Harbor automatically injects `--thinking adaptive` as the default if no explicit `--thinking` level is specified. To use a different intensity, pass `--thinking <level>` explicitly to override.
+
 **Permanent registration:** If you want a named provider (e.g., `my-provider/model-id`) available without `--ae CUSTOM_BASE_URL`, add it to `harbor/src/harbor/agents/installed/openclaw.py` under `_PROVIDER_CONFIGS`:
 
 ```python

--- a/docs/zh/guide/running-tasks.md
+++ b/docs/zh/guide/running-tasks.md
@@ -122,6 +122,8 @@ harbor run -p tasks/watch-shop -a openclaw \
   --ae CUSTOM_REASONING=true
 ```
 
+> **自动推断**：当 `CUSTOM_REASONING=true` 时，若未显式指定 `--thinking`，Harbor 会自动注入 `--thinking adaptive` 作为默认值。如需其他强度，显式传入 `--thinking <level>` 即可覆盖。
+
 **永久注册：** 如果希望使用命名服务商（如 `my-provider/model-id`）而无需每次传 `--ae CUSTOM_BASE_URL`，可在 `harbor/src/harbor/agents/installed/openclaw.py` 的 `_PROVIDER_CONFIGS` 中添加：
 
 ```python

--- a/scripts/run_dataset.sh
+++ b/scripts/run_dataset.sh
@@ -17,6 +17,8 @@ source .env
   -o jobs \
   --ae "CUSTOM_BASE_URL=$OPENAI_BASE_URL" \
   --ae "CUSTOM_API_KEY=$OPENAI_API_KEY" \
+  --ae "CUSTOM_REASONING=true" \
+  --thinking adaptive \
   --ee "JUDGE_BASE_URL=$OPENAI_BASE_URL" \
   --ee "JUDGE_API_KEY=$OPENAI_API_KEY" \
   --ee "JUDGE_MODEL_ID=deepseek-v3.2" \

--- a/scripts/run_runnability_check.sh
+++ b/scripts/run_runnability_check.sh
@@ -51,6 +51,8 @@ for task_dir in tasks/*/; do
             -n 1 -o "jobs/${task}" \
             --ae "CUSTOM_BASE_URL=$BASE_URL" \
             --ae "CUSTOM_API_KEY=$API_KEY" \
+            --ae "CUSTOM_REASONING=true" \
+            --thinking adaptive \
             "${judge_flags[@]+"${judge_flags[@]}"}" \
             >"run_logs/${task}.log" 2>&1
         code=$?


### PR DESCRIPTION
Add CUSTOM_REASONING=true and --thinking adaptive to evaluation scripts and docs.

## Changes
- run_dataset.sh: enable thinking for full dataset evaluation
- run_runnability_check.sh: enable thinking for runnability checks
- docs/zh & docs/en: document auto-injection behavior

## Context
This accompanies the harbor framework change that auto-injects --thinking adaptive when CUSTOM_REASONING=true is set for custom providers.