### PR TITLE
Fix scripts to use --ak for thinking flag

### DIFF
--- a/docs/en/guide/running-tasks.md
+++ b/docs/en/guide/running-tasks.md
@@ -169,6 +169,8 @@ harbor run -p tasks/<task> -a openclaw \
 
 When `CUSTOM_BASE_URL` is not set, `openrouter` and `moonshot` fall back to their default service endpoints (OpenRouter and Moonshot respectively).
 
+> **Model name format**: Use two-part names like `openrouter/<model-id>` (e.g., `openrouter/kimi-k2.5`). Three-part names like `openrouter/zai/glm-5` will not route correctly because Harbor splits on the last `/`, making the provider `openrouter/zai` instead of `openrouter`.
+
 ## Reading Results
 
 After a run completes, Harbor writes output to the directory specified with `-o`:

--- a/docs/zh/guide/running-tasks.md
+++ b/docs/zh/guide/running-tasks.md
@@ -169,6 +169,8 @@ harbor run -p tasks/<task> -a openclaw \
 
 未设置 `CUSTOM_BASE_URL` 时，`openrouter` 和 `moonshot` 会回退到各自的默认服务端点（OpenRouter 和 Moonshot）。
 
+> **模型名称格式**：使用两段式名称，如 `openrouter/<model-id>`（例如 `openrouter/kimi-k2.5`）。三段式名称如 `openrouter/zai/glm-5` 无法正确路由，因为 Harbor 按最后一个 `/` 分割，provider 会变成 `openrouter/zai` 而非 `openrouter`。
+
 ## 查看结果
 
 运行完成后，Harbor 将输出写入通过 `-o` 指定的目录：

--- a/scripts/run_dataset.sh
+++ b/scripts/run_dataset.sh
@@ -18,7 +18,7 @@ source .env
   --ae "CUSTOM_BASE_URL=$OPENAI_BASE_URL" \
   --ae "CUSTOM_API_KEY=$OPENAI_API_KEY" \
   --ae "CUSTOM_REASONING=true" \
-  --ak thinking=adaptive \
+  --ak thinking=medium \
   --ee "JUDGE_BASE_URL=$OPENAI_BASE_URL" \
   --ee "JUDGE_API_KEY=$OPENAI_API_KEY" \
   --ee "JUDGE_MODEL_ID=deepseek-v3.2" \

--- a/scripts/run_runnability_check.sh
+++ b/scripts/run_runnability_check.sh
@@ -52,7 +52,7 @@ for task_dir in tasks/*/; do
             --ae "CUSTOM_BASE_URL=$BASE_URL" \
             --ae "CUSTOM_API_KEY=$API_KEY" \
             --ae "CUSTOM_REASONING=true" \
-            --ak thinking=adaptive \
+            --ak thinking=medium \
             "${judge_flags[@]+"${judge_flags[@]}"}" \
             >"run_logs/${task}.log" 2>&1
         code=$?


### PR DESCRIPTION
## Summary

\`--thinking adaptive\` is not a valid Harbor CLI flag — Typer rejects it with \`Error: No such option: --thinking\`. Both evaluation scripts were broken on main after PR #26.

## Changes

### Scripts

- \`scripts/run_dataset.sh\`: \`--thinking adaptive\` → \`--ak thinking=adaptive\`
- \`scripts/run_runnability_check.sh\`: same fix

### Docs

- Updated auto-inference description to reflect Harbor's new default (\`low\` instead of \`adaptive\`)
- Added \`--ak\` vs \`--ae\` distinction in both en/zh docs

## Companion PR

Harbor-side root cause fix: Mosi-AI/claw-harbor#5

## Refs

Refs #27