### PR TITLE
Switch default provider to moonshot, update thinking auto-inject docs

### DIFF
--- a/docs/en/guide/running-tasks.md
+++ b/docs/en/guide/running-tasks.md
@@ -82,6 +82,7 @@ Models are specified as `<provider>/<model-id>`:
 |--------|---------|
 | `volcengine-plan/<model-id>` | `volcengine-plan/kimi-k2.5` |
 | `volcengine/<model-id>` | `volcengine/deepseek-v3-250324` |
+| `moonshot/<model-id>` | `moonshot/kimi-k2.5` |
 | `anthropic/<model-id>` | `anthropic/claude-opus-4-6` |
 | `openai/<model-id>` | `openai/gpt-4o` |
 | `custom/<model-id>` | `custom/deepseek-chat` |
@@ -122,7 +123,13 @@ harbor run -p tasks/watch-shop -a openclaw \
   --ae CUSTOM_REASONING=true
 ```
 
-> **Auto-inference**: When `CUSTOM_REASONING=true`, Harbor automatically injects `--thinking medium` as the default if no explicit thinking level is specified. To use a different intensity, pass `--ak thinking=<level>` explicitly to override (valid levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`).
+> **Auto-inference**: Harbor automatically injects `--thinking` based on `CUSTOM_REASONING`:
+> - `CUSTOM_REASONING=true` → `--thinking medium` (balances depth and token cost)
+> - `CUSTOM_REASONING=false` → `--thinking off` (explicitly disables thinking)
+>
+> This makes `CUSTOM_REASONING` the single entry point for managing evaluation defaults. To use a different intensity, pass `--ak thinking=<level>` explicitly to override (valid levels: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`).
+>
+> **Priority chain**: `--ak thinking=X` (highest) > `CUSTOM_REASONING` auto-inject > OpenClaw internal default. Explicit `--ak` always wins.
 >
 > **`--ak` vs `--ae`**: Use `--ak key=value` (agent kwarg) to set agent CLI flags such as `thinking`. Use `--ae KEY=VALUE` (agent env) to set environment variables passed to the container (e.g., API keys). Only `--ak` feeds into CLI flag generation; `--ae` values are injected into the container process environment.
 
@@ -241,7 +248,7 @@ For running tasks in parallel without relying on Harbor's `--n-concurrent`, use 
 # See scripts/run_runnability_check.sh for a complete example
 for task in tasks/*/; do
   harbor run -p "$task" -a openclaw \
-    -m custom/kimi-k2.5 \
+    -m moonshot/kimi-k2.5 \
     -n 1 -o "jobs/$(basename $task)" \
     --ae CUSTOM_BASE_URL=... --ae CUSTOM_API_KEY=... &
 done

--- a/docs/zh/guide/running-tasks.md
+++ b/docs/zh/guide/running-tasks.md
@@ -82,6 +82,7 @@ harbor run ... --ae VOLCANO_ENGINE_API_KEY="$VOLCANO_ENGINE_API_KEY"
 |------|------|
 | `volcengine-plan/<model-id>` | `volcengine-plan/kimi-k2.5` |
 | `volcengine/<model-id>` | `volcengine/deepseek-v3-250324` |
+| `moonshot/<model-id>` | `moonshot/kimi-k2.5` |
 | `anthropic/<model-id>` | `anthropic/claude-opus-4-6` |
 | `openai/<model-id>` | `openai/gpt-4o` |
 | `custom/<model-id>` | `custom/deepseek-chat` |
@@ -122,7 +123,13 @@ harbor run -p tasks/watch-shop -a openclaw \
   --ae CUSTOM_REASONING=true
 ```
 
-> **自动推断**：当 `CUSTOM_REASONING=true` 时，若未显式指定 thinking 级别，Harbor 会自动注入 `--thinking medium` 作为默认值。如需其他强度，通过 `--ak thinking=<level>` 显式覆盖（可选值：`off`、`minimal`、`low`、`medium`、`high`、`xhigh`、`adaptive`）。
+> **自动推断**：Harbor 根据 `CUSTOM_REASONING` 自动注入 `--thinking`：
+> - `CUSTOM_REASONING=true` → `--thinking medium`（平衡思考深度与 token 成本）
+> - `CUSTOM_REASONING=false` → `--thinking off`（显式关闭思考）
+>
+> 这使 `CUSTOM_REASONING` 成为统一管理评测默认值的单一入口。如需其他强度，通过 `--ak thinking=<level>` 显式覆盖（可选值：`off`、`minimal`、`low`、`medium`、`high`、`xhigh`、`adaptive`）。
+>
+> **优先级链**：`--ak thinking=X`（最高）> `CUSTOM_REASONING` 自动注入 > OpenClaw 内部默认值。显式 `--ak` 始终优先。
 >
 > **`--ak` 与 `--ae` 的区别**：使用 `--ak key=value`（agent kwarg）设置 agent CLI 参数（如 `thinking`）。使用 `--ae KEY=VALUE`（agent env）设置传入容器的环境变量（如 API key）。只有 `--ak` 会参与 CLI 参数生成；`--ae` 值仅注入容器进程环境。
 
@@ -241,7 +248,7 @@ harbor run --dataset liveclawbench@1.0 \
 # 完整示例参见 scripts/run_runnability_check.sh
 for task in tasks/*/; do
   harbor run -p "$task" -a openclaw \
-    -m custom/kimi-k2.5 \
+    -m moonshot/kimi-k2.5 \
     -n 1 -o "jobs/$(basename $task)" \
     --ae CUSTOM_BASE_URL=... --ae CUSTOM_API_KEY=... &
 done

--- a/scripts/run_dataset.sh
+++ b/scripts/run_dataset.sh
@@ -11,14 +11,13 @@ source .env
 .venv/bin/harbor run --dataset liveclawbench@1.0 \
   --registry-path ./registry.json \
   -a openclaw \
-  -m custom/kimi-k2.5 \
+  -m moonshot/kimi-k2.5 \
   --n-concurrent 4 \
   --n-attempts 1 \
   -o jobs \
   --ae "CUSTOM_BASE_URL=$OPENAI_BASE_URL" \
   --ae "CUSTOM_API_KEY=$OPENAI_API_KEY" \
   --ae "CUSTOM_REASONING=true" \
-  --ak thinking=medium \
   --ee "JUDGE_BASE_URL=$OPENAI_BASE_URL" \
   --ee "JUDGE_API_KEY=$OPENAI_API_KEY" \
   --ee "JUDGE_MODEL_ID=deepseek-v3.2" \

--- a/scripts/run_runnability_check.sh
+++ b/scripts/run_runnability_check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Runnability check: run all 30 tasks with kimi-k2.5 (custom provider)
+# Runnability check: run all 30 tasks with kimi-k2.5 (moonshot provider)
 # Usage: bash scripts/run_runnability_check.sh
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -47,12 +47,11 @@ for task_dir in tasks/*/; do
     echo "[$(date '+%H:%M:%S')] START: $task"
     (
         .venv/bin/harbor run -p "tasks/$task" -a openclaw \
-            -m custom/kimi-k2.5 \
+            -m moonshot/kimi-k2.5 \
             -n 1 -o "jobs/${task}" \
             --ae "CUSTOM_BASE_URL=$BASE_URL" \
             --ae "CUSTOM_API_KEY=$API_KEY" \
             --ae "CUSTOM_REASONING=true" \
-            --ak thinking=medium \
             "${judge_flags[@]+"${judge_flags[@]}"}" \
             >"run_logs/${task}.log" 2>&1
         code=$?


### PR DESCRIPTION
## Summary

- Scripts: `custom/kimi-k2.5` → `moonshot/kimi-k2.5`, remove `--ak thinking=medium` (harbor auto-inject handles it via `CUSTOM_REASONING=true`)
- Docs (en + zh): add `moonshot/` to model name table, document bidirectional auto-inject (`true`→medium, `false`→off), add priority chain explanation

Depends on Mosi-AI/claw-harbor PR for the harbor-side auto-inject logic.

## Test plan

- [ ] Verify `run_dataset.sh` runs correctly with moonshot provider
- [ ] Verify `run_runnability_check.sh` runs correctly
- [ ] Review en/zh docs for accuracy and consistency