### PR TITLE
feat: add smarthome mock service and smarthome_test verification task

### DIFF
--- a/mock-platform/config/task-binary-map.json
+++ b/mock-platform/config/task-binary-map.json
@@ -3,7 +3,7 @@
   "$id": "task-binary-map",
   "description": "Task to mock binary mapping for LiveClawBench per-task Docker images",
   "version": "1.1",
-  "binaries": ["airline", "email", "shop", "todolist", "doc-search"],
+  "binaries": ["airline", "email", "shop", "todolist", "doc-search", "smarthome"],
   "tasks": {
     "watch-shop": {
       "binaries": ["shop"],
@@ -84,6 +84,16 @@
         { "src": "tasks/conflict-repair-acb/environment/documents.sql", "dest": "/opt/mock/data/documents.sql" }
       ]
     },
-    "skill-combination": { "binaries": [] }
+    "skill-combination": { "binaries": [] },
+    "smart-home-thermostat": { "binaries": [] },
+    "grocery-reorder": { "binaries": [] },
+    "smart-home-morning-recovery": { "binaries": [] },
+    "grocery-budget-plan": { "binaries": [] },
+    "smarthome_test": {
+      "binaries": ["smarthome"],
+      "assets": [
+        { "src": "tasks/smarthome_test/environment/seed.sql", "dest": "/opt/mock/data/smarthome.sql" }
+      ]
+    }
   }
 }

--- a/mock-platform/mocks/smarthome/package.json
+++ b/mock-platform/mocks/smarthome/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@mock/smarthome",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "hono": "^4.8.0",
+    "mock-lib": "workspace:*",
+    "react": "^19.2.5"
+  }
+}

--- a/mock-platform/mocks/smarthome/src/index.tsx
+++ b/mock-platform/mocks/smarthome/src/index.tsx
@@ -1,0 +1,1291 @@
+/**
+ * Smart Home mock service — 8-domain home automation mock
+ *
+ * Provides deterministic mock APIs for:
+ * - Room Metrics (read-only)
+ * - Thermostat (GET/POST)
+ * - Coffee Schedule (GET/POST with derived status)
+ * - Inventory (GET/POST/DELETE)
+ * - Grocery Ordering (GET products, POST orders with transactions)
+ * - Wearable/Recovery (read-only)
+ * - Calendar/Workout (GET/PUT with workout_type enum)
+ * - Meal Planning (GET constraints/recipes, POST/GET meal-plan)
+ *
+ * Uses SQLite for persistence with verifier-readable symlink.
+ */
+
+import { createMockApp, startServer } from "mock-lib";
+import type { AppEnv } from "mock-lib";
+import { Hono } from "hono";
+import { html, raw } from "hono/html";
+import type { FC, Child } from "hono/jsx";
+import { Database } from "bun:sqlite";
+import { mkdirSync, existsSync, readFileSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// Room Metrics
+interface RoomMetrics {
+  temperature: number;
+  humidity: number;
+  unit_temp: string;
+  noise?: number;
+  light?: number;
+  air_quality?: number;
+}
+
+// Thermostat
+type ThermostatMode = "comfort" | "eco" | "off";
+
+interface ThermostatSettings {
+  id: number;
+  mode: ThermostatMode;
+  temperature: number;
+  updated_at: string;
+}
+
+// Coffee Schedule
+interface CoffeeSchedule {
+  id: number;
+  start_time: string;
+  updated_at: string;
+}
+
+// Inventory
+interface InventoryItem {
+  id: number;
+  item_name: string;
+  quantity: number;
+  unit: string;
+  location: string;
+  expiry_date?: string;
+  category?: string;
+}
+
+// Grocery
+interface GroceryProduct {
+  product_id: string;
+  name: string;
+  price: number;
+  stock_status: "in_stock" | "low_stock" | "out_of_stock";
+  substitute_for?: string;
+}
+
+interface GroceryOrderItem {
+  id: number;
+  order_id: string;
+  product_id: string;
+  quantity: number;
+  unit_price: number;
+  substitute_for?: string;
+}
+
+interface GroceryOrder {
+  order_id: string;
+  total: number;
+  created_at: string;
+}
+
+// Wearable/Recovery
+interface WearableRecovery {
+  sleep_hours: number;
+  sleep_score: number;
+  readiness: number;
+  resting_heart_rate: number;
+}
+
+// Calendar/Workout
+type WorkoutType = "hiit" | "yoga" | "walking" | "cycling" | "strength" | "stretching" | "swimming" | "rest";
+
+interface CalendarEvent {
+  id: number;
+  title: string;
+  start_time: string;
+  event_type?: string;
+  workout_type?: WorkoutType;
+  updated_at: string;
+}
+
+// Meal Planning
+interface UserConstraints {
+  calorie_target: number;
+  macro_targets: string;
+  allergy_constraints: string;
+  weekly_budget_limit: number;
+}
+
+interface Recipe {
+  id: number;
+  name: string;
+  meal_type: "breakfast" | "lunch" | "dinner";
+  ingredients: string;
+  calories_total: number;
+  allergens?: string;
+}
+
+interface MealPlan {
+  id: number;
+  plan_id: string;
+  created_at: string;
+  plan_data: string;
+}
+
+// Benchmark Clock
+interface BenchmarkClock {
+  id: number;
+  current_time: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Data directory for persistent smarthome state. The per-task startup script creates this
+// directory (mkdir -p, chown mock:mock, chmod 700) and creates verifier-compatible
+// symlink: /tmp/mosi_smart_home.sqlite -> /var/lib/mock-data/smarthome/smarthome.db
+const DATA_DIR = process.env.MOCK_DATA_DIR || "/var/lib/mock-data/smarthome";
+const DB_PATH = `${DATA_DIR}/smarthome.db`;
+const SEED_PATH = process.env.MOCK_SEED_PATH || "/opt/mock/data/smarthome.sql";
+
+let db: Database | null = null;
+
+// ---------------------------------------------------------------------------
+// Database initialization
+// ---------------------------------------------------------------------------
+
+function initDatabase(): void {
+  const dbDir = DB_PATH.substring(0, DB_PATH.lastIndexOf("/"));
+  try {
+    mkdirSync(dbDir, { recursive: true });
+  } catch (err) {
+    console.error(`mock-smarthome: FATAL: cannot create database directory: ${dbDir}`, err);
+    process.exit(1);
+  }
+
+  // Check if DB already exists (for persistence across restart)
+  const dbExists = existsSync(DB_PATH);
+  db = new Database(DB_PATH, { create: true });
+
+  // Create tables with CHECK constraints (idempotent via IF NOT EXISTS)
+  db.exec(`
+    -- Thermostat settings (singleton)
+    CREATE TABLE IF NOT EXISTS thermostat_settings (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      mode TEXT NOT NULL CHECK (mode IN ('comfort', 'eco', 'off')),
+      temperature REAL NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- Coffee schedule (singleton)
+    CREATE TABLE IF NOT EXISTS coffee_schedule (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      start_time TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    -- Benchmark clock for deterministic time-based status
+    CREATE TABLE IF NOT EXISTS benchmark_clock (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      clock_time TEXT NOT NULL
+    );
+
+    -- Room metrics
+    CREATE TABLE IF NOT EXISTS room_metrics (
+      id INTEGER PRIMARY KEY,
+      temperature REAL NOT NULL,
+      humidity REAL NOT NULL,
+      unit_temp TEXT NOT NULL,
+      noise REAL,
+      light REAL,
+      air_quality REAL
+    );
+
+    -- Room info
+    CREATE TABLE IF NOT EXISTS room (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL
+    );
+
+    -- Inventory items
+    CREATE TABLE IF NOT EXISTS inventory_item (
+      id INTEGER PRIMARY KEY,
+      item_name TEXT NOT NULL,
+      quantity REAL NOT NULL,
+      unit TEXT NOT NULL,
+      location TEXT NOT NULL,
+      expiry_date TEXT,
+      category TEXT
+    );
+
+    -- Inventory snapshot (captured at startup)
+    CREATE TABLE IF NOT EXISTS inventory_snapshot (
+      id INTEGER PRIMARY KEY,
+      item_name TEXT NOT NULL,
+      quantity REAL NOT NULL,
+      unit TEXT NOT NULL,
+      location TEXT,
+      captured_at TEXT NOT NULL
+    );
+
+    -- Grocery products (internal catalog)
+    CREATE TABLE IF NOT EXISTS grocery_product (
+      product_id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      price REAL NOT NULL,
+      stock_status TEXT NOT NULL CHECK (stock_status IN ('in_stock', 'low_stock', 'out_of_stock')),
+      substitute_for TEXT
+    );
+
+    -- Grocery orders
+    CREATE TABLE IF NOT EXISTS grocery_order (
+      order_id TEXT PRIMARY KEY,
+      total REAL NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    -- Grocery order items
+    CREATE TABLE IF NOT EXISTS grocery_order_item (
+      id INTEGER PRIMARY KEY,
+      order_id TEXT NOT NULL,
+      product_id TEXT NOT NULL,
+      quantity INTEGER NOT NULL,
+      unit_price REAL NOT NULL,
+      substitute_for TEXT,
+      FOREIGN KEY (order_id) REFERENCES grocery_order(order_id)
+    );
+
+    -- Wearable/recovery state
+    CREATE TABLE IF NOT EXISTS wearable_recovery_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      sleep_hours REAL NOT NULL,
+      sleep_score REAL NOT NULL,
+      readiness REAL NOT NULL,
+      resting_heart_rate REAL NOT NULL
+    );
+
+    -- Calendar events
+    CREATE TABLE IF NOT EXISTS calendar_event (
+      id INTEGER PRIMARY KEY,
+      title TEXT NOT NULL,
+      start_time TEXT NOT NULL,
+      event_type TEXT,
+      workout_type TEXT CHECK (workout_type IN ('hiit', 'yoga', 'walking', 'cycling', 'strength', 'stretching', 'swimming', 'rest') OR workout_type IS NULL),
+      updated_at TEXT NOT NULL
+    );
+
+    -- User constraints
+    CREATE TABLE IF NOT EXISTS user_constraints (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      calorie_target REAL NOT NULL,
+      macro_targets TEXT NOT NULL,
+      allergy_constraints TEXT NOT NULL,
+      weekly_budget_limit REAL NOT NULL
+    );
+
+    -- Recipes
+    CREATE TABLE IF NOT EXISTS recipe (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      meal_type TEXT NOT NULL CHECK (meal_type IN ('breakfast', 'lunch', 'dinner')),
+      ingredients TEXT NOT NULL,
+      calories_total REAL NOT NULL,
+      allergens TEXT
+    );
+
+    -- Recipe nutrition (per-ingredient breakdown)
+    CREATE TABLE IF NOT EXISTS recipe_nutrition (
+      id INTEGER PRIMARY KEY,
+      meal_id INTEGER NOT NULL,
+      ingredient_name TEXT NOT NULL,
+      quantity REAL NOT NULL,
+      unit TEXT NOT NULL,
+      calories REAL NOT NULL,
+      protein_g REAL,
+      carbs_g REAL,
+      fat_g REAL,
+      FOREIGN KEY (meal_id) REFERENCES recipe(id)
+    );
+
+    -- Meal plans
+    CREATE TABLE IF NOT EXISTS meal_plan (
+      id INTEGER PRIMARY KEY,
+      plan_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      plan_data TEXT NOT NULL
+    );
+
+    -- Substitution mapping
+    CREATE TABLE IF NOT EXISTS substitution_mapping (
+      id INTEGER PRIMARY KEY,
+      original_item TEXT NOT NULL,
+      substitute_item TEXT NOT NULL,
+      substitution_ratio REAL NOT NULL,
+      category TEXT
+    );
+  `);
+
+  // Load seed SQL only on first init (fresh DB), preserve existing state on restart
+  if (!dbExists && existsSync(SEED_PATH)) {
+    const sql = readFileSync(SEED_PATH, "utf-8");
+    db.exec(sql);
+    console.log(`mock-smarthome: initialized fresh DB from ${SEED_PATH}`);
+  } else if (dbExists) {
+    console.log(`mock-smarthome: found existing DB at ${DB_PATH}, preserving state`);
+  } else {
+    console.log(`mock-smarthome: no seed SQL found at ${SEED_PATH}, using empty tables`);
+  }
+
+  // Populate inventory_snapshot from inventory_item (only if snapshot is empty)
+  populateInventorySnapshot();
+}
+
+function populateInventorySnapshot(): void {
+  const database = assertDb();
+
+  // Check if snapshot already exists
+  const existing = database.query("SELECT COUNT(*) as count FROM inventory_snapshot").get() as { count: number };
+  if (existing.count > 0) {
+    return;
+  }
+
+  // Use benchmark_clock for deterministic captured_at, fallback to seed time if not set
+  const clock = database.query("SELECT clock_time FROM benchmark_clock WHERE id = 1").get() as { clock_time: string } | null;
+  const capturedAt = clock?.clock_time || "2026-05-06T08:00:00Z";
+
+  // Copy inventory items to snapshot
+  database.exec(`
+    INSERT INTO inventory_snapshot (item_name, quantity, unit, location, captured_at)
+    SELECT item_name, quantity, unit, location, '${capturedAt}'
+    FROM inventory_item
+  `);
+  console.log("mock-smarthome: populated inventory_snapshot from inventory_item");
+}
+
+function assertDb(): Database {
+  if (!db) {
+    throw new Error("Database not initialized");
+  }
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+function isValidThermostatMode(mode: string): mode is ThermostatMode {
+  return ["comfort", "eco", "off"].includes(mode.toLowerCase());
+}
+
+function isValidWorkoutType(type: string): type is WorkoutType {
+  return ["hiit", "yoga", "walking", "cycling", "strength", "stretching", "swimming", "rest"].includes(type.toLowerCase());
+}
+
+// Get deterministic timestamp from benchmark_clock (required for benchmark-verifiable state)
+function getBenchmarkTime(): string {
+  const database = assertDb();
+  const clock = database.query("SELECT clock_time FROM benchmark_clock WHERE id = 1").get() as { clock_time: string } | null;
+  return clock?.clock_time || "2026-05-06T08:00:00Z";
+}
+
+// Derive coffee status from start_time and benchmark_clock in a timezone-stable way
+function deriveCoffeeStatus(startTime: string, currentTime: string): string {
+  // Parse HH:MM start time
+  const [startHour, startMin] = startTime.split(":").map(Number);
+  const startMinutes = startHour * 60 + startMin;
+
+  // Parse ISO 8601 current time in a timezone-stable way (use UTC)
+  // Format: 2026-05-06T06:45:00Z
+  const timeMatch = currentTime.match(/T(\d{2}):(\d{2}):/);
+  if (!timeMatch) {
+    return "scheduled"; // Fallback if time format is invalid
+  }
+  const currentHour = parseInt(timeMatch[1], 10);
+  const currentMin = parseInt(timeMatch[2], 10);
+  const currentMinutes = currentHour * 60 + currentMin;
+
+  if (currentMinutes < startMinutes - 30) {
+    return "scheduled";
+  } else if (currentMinutes < startMinutes) {
+    return "preparing";
+  } else if (currentMinutes < startMinutes + 30) {
+    return "brewing";
+  } else {
+    return "ready";
+  }
+}
+
+// Generate deterministic order ID based on benchmark clock and database state
+function generateOrderId(): string {
+  const database = assertDb();
+  const time = getBenchmarkTime();
+  const timestamp = time.replace(/[-:T]/g, "").substring(0, 14);
+
+  // Query existing orders with same timestamp prefix to get next suffix
+  const prefix = `ORD${timestamp}-`;
+  const existing = database.query("SELECT order_id FROM grocery_order WHERE order_id LIKE ? ORDER BY order_id DESC LIMIT 1").all(`${prefix}%`) as { order_id: string }[];
+  let nextSuffix = 1;
+  if (existing.length > 0) {
+    const lastSuffix = existing[0].order_id.substring(prefix.length);
+    nextSuffix = parseInt(lastSuffix, 36) + 1;
+  }
+
+  return `ORD${timestamp}-${nextSuffix.toString(36).toUpperCase().padStart(3, "0")}`;
+}
+
+// Generate deterministic plan ID based on benchmark clock and database state
+function generatePlanId(): string {
+  const database = assertDb();
+  const time = getBenchmarkTime();
+  const timestamp = time.replace(/[-:T]/g, "").substring(0, 14);
+
+  // Query existing plans with same timestamp prefix to get next suffix
+  const prefix = `PLAN${timestamp}-`;
+  const existing = database.query("SELECT plan_id FROM meal_plan WHERE plan_id LIKE ? ORDER BY plan_id DESC LIMIT 1").all(`${prefix}%`) as { plan_id: string }[];
+  let nextSuffix = 1;
+  if (existing.length > 0) {
+    const lastSuffix = existing[0].plan_id.substring(prefix.length);
+    nextSuffix = parseInt(lastSuffix, 36) + 1;
+  }
+
+  return `PLAN${timestamp}-${nextSuffix.toString(36).toUpperCase().padStart(3, "0")}`;
+}
+
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+function escJs(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+}
+
+// ---------------------------------------------------------------------------
+// TSX Template Components
+// ---------------------------------------------------------------------------
+
+const Layout: FC<{ title: string; children: Child; scripts?: string }> = ({ title, children, scripts }) => {
+  return html`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${title}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+  .container { max-width: 1200px; margin: 0 auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+  h1 { color: #232F3E; margin-bottom: 20px; }
+  h2 { color: #232F3E; margin-top: 30px; }
+  .nav { display: flex; gap: 15px; margin-bottom: 20px; padding-bottom: 15px; border-bottom: 1px solid #e0e0e0; flex-wrap: wrap; }
+  .nav a { color: #667eea; text-decoration: none; padding: 8px 16px; border-radius: 4px; background: #f8f9fa; }
+  .nav a:hover { background: #667eea; color: white; }
+  .card { background: #f8f9fa; padding: 15px; border-radius: 8px; margin-bottom: 15px; }
+  .metric { display: flex; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid #e0e0e0; }
+  .metric:last-child { border-bottom: none; }
+  .metric-label { color: #666; }
+  .metric-value { font-weight: 600; color: #232F3E; }
+  .btn { background: #667eea; color: white; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer; font-size: 14px; }
+  .btn:hover { background: #5a6fd6; }
+  .btn-secondary { background: #6c757d; }
+  .btn-danger { background: #dc3545; }
+  input, select { padding: 8px 12px; border: 1px solid #ddd; border-radius: 4px; margin-right: 10px; }
+  table { width: 100%; border-collapse: collapse; margin-top: 15px; }
+  th, td { padding: 12px; text-align: left; border-bottom: 1px solid #e0e0e0; }
+  th { background: #f8f9fa; font-weight: 600; }
+  .status-badge { padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: 500; }
+  .status-scheduled { background: #e3f2fd; color: #1976d2; }
+  .status-brewing { background: #fff3e0; color: #f57c00; }
+  .status-ready { background: #e8f5e9; color: #388e3c; }
+</style>
+</head>
+<body>
+<div class="container">
+<nav class="nav">
+<a href="/">Dashboard</a>
+<a href="/thermostat">Thermostat</a>
+<a href="/inventory">Inventory</a>
+<a href="/grocery">Grocery</a>
+<a href="/calendar">Calendar</a>
+<a href="/meal-plan">Meal Plan</a>
+</nav>
+${children}
+</div>
+${scripts ? html`<script>${raw(scripts)}</script>` : ""}
+</body>
+</html>`;
+};
+
+// Error page for 500 errors
+const ErrorPage: FC<{ title: string; message: string }> = ({ title, message }) => {
+  return html`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${title}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 40px; background: #f5f5f5; }
+  .error-container { max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+  h1 { color: #dc3545; margin-bottom: 20px; }
+  p { color: #666; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="error-container">
+<h1>${title}</h1>
+<p>${message}</p>
+</div>
+</body>
+</html>`;
+};
+
+// Dashboard page
+const DashboardPage: FC<{ metrics: RoomMetrics; thermostat: ThermostatSettings }> = ({ metrics, thermostat }) => {
+  return <Layout title="Smart Home Dashboard">
+    <h1>Smart Home Dashboard</h1>
+
+    <h2>Room Metrics</h2>
+    <div class="card">
+      <div class="metric">
+        <span class="metric-label">Temperature</span>
+        <span class="metric-value">{`${metrics.temperature}°${metrics.unit_temp}`}</span>
+      </div>
+      <div class="metric">
+        <span class="metric-label">Humidity</span>
+        <span class="metric-value">{`${metrics.humidity}%`}</span>
+      </div>
+      {metrics.noise != null ? (
+        <div class="metric">
+          <span class="metric-label">Noise Level</span>
+          <span class="metric-value">{`${metrics.noise} dB`}</span>
+        </div>
+      ) : null}
+      {metrics.light != null ? (
+        <div class="metric">
+          <span class="metric-label">Light</span>
+          <span class="metric-value">{`${metrics.light} lux`}</span>
+        </div>
+      ) : null}
+      {metrics.air_quality != null ? (
+        <div class="metric">
+          <span class="metric-label">Air Quality</span>
+          <span class="metric-value">{metrics.air_quality}</span>
+        </div>
+      ) : null}
+    </div>
+
+    <h2>Thermostat</h2>
+    <div class="card">
+      <div class="metric">
+        <span class="metric-label">Mode</span>
+        <span class="metric-value">{thermostat.mode.toUpperCase()}</span>
+      </div>
+      <div class="metric">
+        <span class="metric-label">Target Temperature</span>
+        <span class="metric-value">{`${thermostat.temperature}°F`}</span>
+      </div>
+    </div>
+  </Layout>;
+};
+
+// Thermostat page
+const ThermostatPage: FC<{ thermostat: ThermostatSettings }> = ({ thermostat }) => {
+  return <Layout title="Thermostat Control" scripts={`
+async function updateThermostat() {
+  const mode = document.getElementById('mode').value;
+  const temperature = parseFloat(document.getElementById('temperature').value);
+  if (isNaN(temperature)) { alert('Please enter a valid temperature'); return; }
+  try {
+    const response = await fetch('/api/thermostat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode, temperature })
+    });
+    const data = await response.json();
+    if (data.error) { alert('Error: ' + data.error); }
+    else { location.reload(); }
+  } catch (err) { alert('Failed to update thermostat'); }
+}
+`}>
+    <h1>Thermostat Control</h1>
+    <div class="card">
+      <div class="metric">
+        <span class="metric-label">Current Mode</span>
+        <span class="metric-value">{thermostat.mode.toUpperCase()}</span>
+      </div>
+      <div class="metric">
+        <span class="metric-label">Target Temperature</span>
+        <span class="metric-value">{`${thermostat.temperature}°F`}</span>
+      </div>
+    </div>
+
+    <h2>Update Settings</h2>
+    <div class="card">
+      <select id="mode">
+        <option value="comfort" selected={thermostat.mode === "comfort"}>Comfort</option>
+        <option value="eco" selected={thermostat.mode === "eco"}>Eco</option>
+        <option value="off" selected={thermostat.mode === "off"}>Off</option>
+      </select>
+      <input type="number" id="temperature" value={thermostat.temperature} step="1" min="50" max="90" placeholder="Temperature (°F)" />
+      <button class="btn" onclick="updateThermostat()">Update</button>
+    </div>
+  </Layout>;
+};
+
+// Inventory page
+const InventoryPage: FC<{ items: InventoryItem[] }> = ({ items }) => {
+  const fridgeItems = items.filter(i => i.location === "fridge");
+  const pantryItems = items.filter(i => i.location === "pantry");
+
+  return <Layout title="Inventory" scripts={`
+async function deleteItem(id) {
+  if (!confirm('Delete this item?')) return;
+  try {
+    const response = await fetch('/api/inventory/' + id, { method: 'DELETE' });
+    const data = await response.json();
+    if (data.error) alert('Error: ' + data.error);
+    else location.reload();
+  } catch (err) { alert('Failed to delete item'); }
+}
+`}>
+    <h1>Inventory</h1>
+
+    <h2>Fridge</h2>
+    {fridgeItems.length > 0 ? (
+      <table>
+        <thead><tr><th>Item</th><th>Quantity</th><th>Unit</th><th>Expiry</th><th>Actions</th></tr></thead>
+        <tbody>
+          {fridgeItems.map(item => (
+            <tr>
+              <td>{item.item_name}</td>
+              <td>{item.quantity}</td>
+              <td>{item.unit}</td>
+              <td>{item.expiry_date || "-"}</td>
+              <td><button class="btn btn-danger" onclick={`deleteItem(${item.id})`}>Delete</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ) : <p>No items in fridge.</p>}
+
+    <h2>Pantry</h2>
+    {pantryItems.length > 0 ? (
+      <table>
+        <thead><tr><th>Item</th><th>Quantity</th><th>Unit</th><th>Category</th><th>Actions</th></tr></thead>
+        <tbody>
+          {pantryItems.map(item => (
+            <tr>
+              <td>{item.item_name}</td>
+              <td>{item.quantity}</td>
+              <td>{item.unit}</td>
+              <td>{item.category || "-"}</td>
+              <td><button class="btn btn-danger" onclick={`deleteItem(${item.id})`}>Delete</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ) : <p>No items in pantry.</p>}
+  </Layout>;
+};
+
+// Grocery page
+const GroceryPage: FC<{ products: GroceryProduct[] }> = ({ products }) => {
+  return <Layout title="Grocery Catalog">
+    <h1>Grocery Catalog</h1>
+    <table>
+      <thead><tr><th>Product</th><th>Price</th><th>Stock</th></tr></thead>
+      <tbody>
+        {products.map(p => (
+          <tr>
+            <td>{p.name}</td>
+            <td>{`$${p.price.toFixed(2)}`}</td>
+            <td>
+              <span class={`status-badge ${p.stock_status === "in_stock" ? "status-ready" : p.stock_status === "low_stock" ? "status-brewing" : "status-scheduled"}`}>
+                {p.stock_status.replace("_", " ").toUpperCase()}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </Layout>;
+};
+
+// Calendar page
+const CalendarPage: FC<{ events: CalendarEvent[] }> = ({ events }) => {
+  return <Layout title="Calendar" scripts={`
+async function updateWorkout(id) {
+  const workoutType = document.getElementById('workout-' + id).value;
+  try {
+    const response = await fetch('/api/calendar/' + id, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workout_type: workoutType })
+    });
+    const data = await response.json();
+    if (data.error) alert('Error: ' + data.error);
+    else location.reload();
+  } catch (err) { alert('Failed to update workout'); }
+}
+`}>
+    <h1>Calendar</h1>
+    <table>
+      <thead><tr><th>Event</th><th>Time</th><th>Type</th><th>Workout</th><th>Actions</th></tr></thead>
+      <tbody>
+        {events.map(event => (
+          <tr>
+            <td>{event.title}</td>
+            <td>{event.start_time}</td>
+            <td>{event.event_type || "-"}</td>
+            <td>
+              {event.workout_type ? (
+                event.event_type === "workout" ? (
+                  <select id={`workout-${event.id}`} onchange={`updateWorkout(${event.id})`}>
+                    <option value="hiit" selected={event.workout_type === "hiit"}>HIIT</option>
+                    <option value="yoga" selected={event.workout_type === "yoga"}>Yoga</option>
+                    <option value="walking" selected={event.workout_type === "walking"}>Walking</option>
+                    <option value="cycling" selected={event.workout_type === "cycling"}>Cycling</option>
+                    <option value="strength" selected={event.workout_type === "strength"}>Strength</option>
+                    <option value="stretching" selected={event.workout_type === "stretching"}>Stretching</option>
+                    <option value="swimming" selected={event.workout_type === "swimming"}>Swimming</option>
+                    <option value="rest" selected={event.workout_type === "rest"}>Rest</option>
+                  </select>
+                ) : event.workout_type
+              ) : "-"}
+            </td>
+            <td>-</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </Layout>;
+};
+
+// Meal Plan page
+const MealPlanPage: FC<{ constraints: UserConstraints; recipes: Recipe[] }> = ({ constraints, recipes }) => {
+  return <Layout title="Meal Planning">
+    <h1>Meal Planning</h1>
+
+    <h2>Your Constraints</h2>
+    <div class="card">
+      <div class="metric">
+        <span class="metric-label">Calorie Target</span>
+        <span class="metric-value">{`${constraints.calorie_target} kcal/day`}</span>
+      </div>
+      <div class="metric">
+        <span class="metric-label">Weekly Budget</span>
+        <span class="metric-value">{`$${constraints.weekly_budget_limit}`}</span>
+      </div>
+      <div class="metric">
+        <span class="metric-label">Allergies</span>
+        <span class="metric-value">{constraints.allergy_constraints}</span>
+      </div>
+    </div>
+
+    <h2>Available Recipes</h2>
+    <table>
+      <thead><tr><th>Name</th><th>Meal</th><th>Calories</th><th>Allergens</th></tr></thead>
+      <tbody>
+        {recipes.map(r => (
+          <tr>
+            <td>{r.name}</td>
+            <td>{r.meal_type}</td>
+            <td>{`${r.calories_total} kcal`}</td>
+            <td>{r.allergens || "-"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </Layout>;
+};
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+function registerRoutes(app: Hono<AppEnv>): void {
+  // Sentinel route for binary isolation verification
+  app.get("/__mock_sentinel__/smarthome", (c) =>
+    c.json({ mock: "smarthome", sentinel: true }),
+  );
+
+  // --- HTML Pages ---
+
+  // Dashboard
+  app.get("/", (c) => {
+    const database = assertDb();
+    const metrics = database.query("SELECT * FROM room_metrics LIMIT 1").get() as RoomMetrics;
+    const thermostat = database.query("SELECT * FROM thermostat_settings WHERE id = 1").get() as ThermostatSettings;
+
+    if (!metrics || !thermostat) {
+      return c.html(<ErrorPage title="Service Error" message="Required data unavailable. Please check system configuration." />, 500);
+    }
+
+    return c.html(<DashboardPage metrics={metrics} thermostat={thermostat} />);
+  });
+
+  // Thermostat page
+  app.get("/thermostat", (c) => {
+    const database = assertDb();
+    const thermostat = database.query("SELECT * FROM thermostat_settings WHERE id = 1").get() as ThermostatSettings;
+
+    if (!thermostat) {
+      return c.html(<ErrorPage title="Service Error" message="Thermostat data unavailable. Please check system configuration." />, 500);
+    }
+
+    return c.html(<ThermostatPage thermostat={thermostat} />);
+  });
+
+  // Inventory page
+  app.get("/inventory", (c) => {
+    const database = assertDb();
+    const items = database.query("SELECT * FROM inventory_item ORDER BY location, item_name").all() as InventoryItem[];
+    // Inventory can be empty, no error needed
+    return c.html(<InventoryPage items={items} />);
+  });
+
+  // Grocery page
+  app.get("/grocery", (c) => {
+    const database = assertDb();
+    const products = database.query("SELECT * FROM grocery_product ORDER BY name").all() as GroceryProduct[];
+    // Grocery catalog can be empty, no error needed
+    return c.html(<GroceryPage products={products} />);
+  });
+
+  // Calendar page
+  app.get("/calendar", (c) => {
+    const database = assertDb();
+    const events = database.query("SELECT * FROM calendar_event ORDER BY start_time").all() as CalendarEvent[];
+    // Calendar can be empty, no error needed
+    return c.html(<CalendarPage events={events} />);
+  });
+
+  // Meal Plan page
+  app.get("/meal-plan", (c) => {
+    const database = assertDb();
+    const constraints = database.query("SELECT * FROM user_constraints WHERE id = 1").get() as UserConstraints;
+    const recipes = database.query("SELECT * FROM recipe ORDER BY meal_type, name").all() as Recipe[];
+
+    if (!constraints) {
+      return c.html(<ErrorPage title="Service Error" message="Constraints data unavailable. Please check system configuration." />, 500);
+    }
+
+    return c.html(<MealPlanPage constraints={constraints} recipes={recipes} />);
+  });
+
+  // --- API Routes ---
+
+  // Room Metrics API
+  app.get("/api/room-metrics", (c) => {
+    const database = assertDb();
+    const metrics = database.query("SELECT temperature, humidity, unit_temp, noise, light, air_quality FROM room_metrics LIMIT 1").get();
+    if (!metrics) {
+      return c.json({ error: "Room metrics unavailable" }, 503);
+    }
+    return c.json(metrics);
+  });
+
+  // Thermostat API
+  app.get("/api/thermostat", (c) => {
+    const database = assertDb();
+    const thermostat = database.query("SELECT mode, temperature, updated_at FROM thermostat_settings WHERE id = 1").get();
+    if (!thermostat) {
+      return c.json({ error: "Thermostat settings not found" }, 404);
+    }
+    return c.json(thermostat);
+  });
+
+  app.post("/api/thermostat", async (c) => {
+    let body: { mode?: string; temperature?: number };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const mode = body.mode?.toLowerCase();
+    const temperature = body.temperature;
+
+    if (!mode || !isValidThermostatMode(mode)) {
+      return c.json({ error: "Invalid mode. Must be comfort, eco, or off" }, 400);
+    }
+
+    if (typeof temperature !== "number" || !Number.isFinite(temperature)) {
+      return c.json({ error: "Temperature must be a valid number" }, 400);
+    }
+
+    const database = assertDb();
+
+    // Verify singleton exists before update
+    const existing = database.query("SELECT id FROM thermostat_settings WHERE id = 1").get();
+    if (!existing) {
+      return c.json({ error: "Thermostat settings unavailable - required state not initialized" }, 503);
+    }
+
+    const now = getBenchmarkTime();
+    database.query("UPDATE thermostat_settings SET mode = ?, temperature = ?, updated_at = ? WHERE id = 1").run(mode, temperature, now);
+
+    return c.json({ mode, temperature, updated_at: now });
+  });
+
+  // Coffee Schedule API
+  app.get("/api/coffee-schedule", (c) => {
+    const database = assertDb();
+    const schedule = database.query("SELECT start_time, updated_at FROM coffee_schedule WHERE id = 1").get() as { start_time: string; updated_at: string };
+    const clock = database.query("SELECT clock_time FROM benchmark_clock WHERE id = 1").get() as { clock_time: string };
+
+    if (!schedule) {
+      return c.json({ error: "Coffee schedule not found" }, 404);
+    }
+
+    const status = clock ? deriveCoffeeStatus(schedule.start_time, clock.clock_time) : "scheduled";
+    return c.json({ start_time: schedule.start_time, status, updated_at: schedule.updated_at });
+  });
+
+  app.post("/api/coffee-schedule", async (c) => {
+    let body: { start_time?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const startTime = body.start_time;
+    if (!startTime || !/^\d{2}:\d{2}$/.test(startTime)) {
+      return c.json({ error: "Invalid start_time format. Use HH:MM format" }, 400);
+    }
+
+    // Validate HH:MM bounds (reject invalid times like 29:99)
+    const [hour, min] = startTime.split(":").map(Number);
+    if (hour < 0 || hour > 23 || min < 0 || min > 59) {
+      return c.json({ error: "Invalid time value. Hour must be 0-23, minute must be 0-59" }, 400);
+    }
+
+    const database = assertDb();
+
+    // Verify singleton exists before update
+    const existing = database.query("SELECT id FROM coffee_schedule WHERE id = 1").get();
+    if (!existing) {
+      return c.json({ error: "Coffee schedule unavailable - required state not initialized" }, 503);
+    }
+
+    const now = getBenchmarkTime();
+    database.query("UPDATE coffee_schedule SET start_time = ?, updated_at = ? WHERE id = 1").run(startTime, now);
+
+    return c.json({ start_time: startTime, updated_at: now });
+  });
+
+  // Inventory API
+  app.get("/api/inventory", (c) => {
+    const database = assertDb();
+    const location = c.req.query("location");
+
+    let query = "SELECT id, item_name, quantity, unit, location, expiry_date, category FROM inventory_item";
+    const params: string[] = [];
+
+    if (location) {
+      query += " WHERE location = ?";
+      params.push(location);
+    }
+
+    const items = database.query(query).all(...params) as InventoryItem[];
+    return c.json(items);
+  });
+
+  app.post("/api/inventory", async (c) => {
+    let body: Partial<InventoryItem>;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    if (!body.item_name || typeof body.quantity !== "number" || !body.unit || !body.location) {
+      return c.json({ error: "Missing required fields: item_name, quantity, unit, location" }, 400);
+    }
+
+    const database = assertDb();
+    const result = database.query(
+      "INSERT INTO inventory_item (item_name, quantity, unit, location, expiry_date, category) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run(body.item_name, body.quantity, body.unit, body.location, body.expiry_date || null, body.category || null);
+
+    return c.json({
+      id: result.lastInsertRowid as number,
+      item_name: body.item_name,
+      quantity: body.quantity,
+      unit: body.unit,
+      location: body.location,
+      expiry_date: body.expiry_date,
+      category: body.category
+    }, 201);
+  });
+
+  app.delete("/api/inventory/:id", (c) => {
+    const id = c.req.param("id");
+    const database = assertDb();
+
+    const existing = database.query("SELECT id FROM inventory_item WHERE id = ?").get(id);
+    if (!existing) {
+      return c.json({ error: "Item not found" }, 404);
+    }
+
+    database.query("DELETE FROM inventory_item WHERE id = ?").run(id);
+    return c.json({ success: true });
+  });
+
+  // Grocery API
+  app.get("/api/grocery/products", (c) => {
+    const database = assertDb();
+    const products = database.query("SELECT product_id, name, price, stock_status, substitute_for FROM grocery_product ORDER BY name").all();
+    return c.json(products);
+  });
+
+  app.post("/api/grocery/orders", async (c) => {
+    let body: { items?: Array<{ product_id: string; quantity: number; substitute_for?: string }> };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const items = body.items;
+    if (!items || !Array.isArray(items) || items.length === 0) {
+      return c.json({ error: "Items array required" }, 400);
+    }
+
+    const database = assertDb();
+
+    // Validate products and calculate total
+    let total = 0;
+    const orderItems: Array<{ product_id: string; quantity: number; unit_price: number; substitute_for?: string }> = [];
+
+    for (const item of items) {
+      if (!item.product_id || typeof item.quantity !== "number" || item.quantity <= 0) {
+        return c.json({ error: "Invalid item: product_id and positive quantity required" }, 400);
+      }
+
+      const product = database.query("SELECT product_id, name, price, stock_status FROM grocery_product WHERE product_id = ?").get(item.product_id) as GroceryProduct | undefined;
+      if (!product) {
+        return c.json({ error: `Product not found: ${item.product_id}` }, 404);
+      }
+
+      if (product.stock_status === "out_of_stock" && !item.substitute_for) {
+        return c.json({ error: `Product out of stock and no substitute provided: ${item.product_id}` }, 409);
+      }
+
+      total += product.price * item.quantity;
+      orderItems.push({
+        product_id: item.product_id,
+        quantity: item.quantity,
+        unit_price: product.price,
+        substitute_for: item.substitute_for
+      });
+    }
+
+    // Create order with transaction
+    const orderId = generateOrderId();
+    const now = getBenchmarkTime();
+
+    const createOrder = database.transaction(() => {
+      database.query("INSERT INTO grocery_order (order_id, total, created_at) VALUES (?, ?, ?)").run(orderId, total, now);
+
+      for (const orderItem of orderItems) {
+        database.query(
+          "INSERT INTO grocery_order_item (order_id, product_id, quantity, unit_price, substitute_for) VALUES (?, ?, ?, ?, ?)"
+        ).run(orderId, orderItem.product_id, orderItem.quantity, orderItem.unit_price, orderItem.substitute_for || null);
+      }
+    });
+
+    createOrder();
+
+    return c.json({
+      success: true,
+      order_id: orderId,
+      total: Math.round(total * 100) / 100,
+      items: orderItems
+    }, 201);
+  });
+
+  // Wearable/Recovery API
+  app.get("/api/wearable-recovery", (c) => {
+    const database = assertDb();
+    const data = database.query("SELECT sleep_hours, sleep_score, readiness, resting_heart_rate FROM wearable_recovery_state WHERE id = 1").get();
+    if (!data) {
+      return c.json({ error: "Wearable data unavailable" }, 503);
+    }
+    return c.json(data);
+  });
+
+  // Calendar/Workout API
+  app.get("/api/calendar", (c) => {
+    const database = assertDb();
+    const events = database.query("SELECT id, title, start_time, event_type, workout_type, updated_at FROM calendar_event ORDER BY start_time").all();
+    return c.json(events);
+  });
+
+  app.get("/api/calendar/:id", (c) => {
+    const id = c.req.param("id");
+    const database = assertDb();
+    const event = database.query("SELECT id, title, start_time, event_type, workout_type, updated_at FROM calendar_event WHERE id = ?").get(id);
+
+    if (!event) {
+      return c.json({ error: "Event not found" }, 404);
+    }
+
+    return c.json(event);
+  });
+
+  app.put("/api/calendar/:id", async (c) => {
+    const id = c.req.param("id");
+    let body: { title?: string; start_time?: string; event_type?: string; workout_type?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const database = assertDb();
+    const existing = database.query("SELECT id FROM calendar_event WHERE id = ?").get(id);
+    if (!existing) {
+      return c.json({ error: "Event not found" }, 404);
+    }
+
+    // Validate workout_type if provided
+    if (body.workout_type !== undefined && body.workout_type !== null && !isValidWorkoutType(body.workout_type)) {
+      return c.json({ error: "Invalid workout_type" }, 400);
+    }
+
+    // Normalize workout_type to lowercase before persisting (matches thermostat mode handling)
+    const normalizedWorkoutType = body.workout_type !== undefined && body.workout_type !== null
+      ? body.workout_type.toLowerCase()
+      : null;
+
+    const now = getBenchmarkTime();
+    database.query(
+      "UPDATE calendar_event SET title = COALESCE(?, title), start_time = COALESCE(?, start_time), event_type = COALESCE(?, event_type), workout_type = ?, updated_at = ? WHERE id = ?"
+    ).run(body.title || null, body.start_time || null, body.event_type || null, normalizedWorkoutType, now, id);
+
+    const updated = database.query("SELECT id, title, start_time, event_type, workout_type, updated_at FROM calendar_event WHERE id = ?").get(id);
+    return c.json(updated);
+  });
+
+  // Constraints API
+  app.get("/api/constraints", (c) => {
+    const database = assertDb();
+    const constraints = database.query("SELECT calorie_target, macro_targets, allergy_constraints, weekly_budget_limit FROM user_constraints WHERE id = 1").get();
+    if (!constraints) {
+      return c.json({ error: "Constraints not found" }, 404);
+    }
+    return c.json(constraints);
+  });
+
+  // Recipes API
+  app.get("/api/recipes", (c) => {
+    const database = assertDb();
+    const recipes = database.query("SELECT id, name, meal_type, ingredients, calories_total, allergens FROM recipe ORDER BY meal_type, name").all();
+    return c.json(recipes);
+  });
+
+  // Meal Plan API
+  app.get("/api/meal-plan", (c) => {
+    const database = assertDb();
+    // Use id DESC as tie-breaker for deterministic retrieval when multiple plans share the same created_at
+    const plan = database.query("SELECT plan_id, created_at, plan_data FROM meal_plan ORDER BY created_at DESC, id DESC LIMIT 1").get();
+    if (!plan) {
+      return c.json({ error: "No meal plan found" }, 404);
+    }
+    return c.json(plan);
+  });
+
+  app.post("/api/meal-plan", async (c) => {
+    let body: { days?: Array<{ date: string; meals: Array<{ meal_type: string; meal_id: number }> }> };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const days = body.days;
+    if (!days || !Array.isArray(days) || days.length !== 7) {
+      return c.json({ error: "Exactly 7 days required for weekly meal plan" }, 400);
+    }
+
+    // Validate each day's structure
+    const validMealTypes = ["breakfast", "lunch", "dinner"];
+    const isoDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+
+    for (let i = 0; i < days.length; i++) {
+      const day = days[i];
+
+      // Validate date is a valid ISO date string (YYYY-MM-DD)
+      if (!day.date || typeof day.date !== "string" || !isoDateRegex.test(day.date)) {
+        return c.json({ error: `Day ${i + 1}: date must be a valid ISO date string (YYYY-MM-DD)` }, 400);
+      }
+
+      // Validate date components (reject invalid dates like 2026-13-45)
+      const [year, month, date] = day.date.split("-").map(Number);
+      if (year < 2000 || year > 2100 || month < 1 || month > 12 || date < 1 || date > 31) {
+        return c.json({ error: `Day ${i + 1}: invalid date value` }, 400);
+      }
+
+      // Validate meals array exists
+      if (!day.meals || !Array.isArray(day.meals)) {
+        return c.json({ error: `Day ${i + 1}: meals must be an array` }, 400);
+      }
+
+      // Validate each meal
+      for (let j = 0; j < day.meals.length; j++) {
+        const meal = day.meals[j];
+
+        // Validate meal_type
+        if (!meal.meal_type || typeof meal.meal_type !== "string" || !validMealTypes.includes(meal.meal_type)) {
+          return c.json({ error: `Day ${i + 1}, meal ${j + 1}: meal_type must be one of breakfast, lunch, dinner` }, 400);
+        }
+
+        // Validate meal_id
+        if (typeof meal.meal_id !== "number" || !Number.isInteger(meal.meal_id)) {
+          return c.json({ error: `Day ${i + 1}, meal ${j + 1}: meal_id must be an integer` }, 400);
+        }
+      }
+    }
+
+    const database = assertDb();
+
+    // Validate meal_ids exist
+    for (const day of days) {
+      for (const meal of day.meals) {
+        const recipe = database.query("SELECT id FROM recipe WHERE id = ?").get(meal.meal_id);
+        if (!recipe) {
+          return c.json({ error: `Recipe not found: ${meal.meal_id}` }, 404);
+        }
+      }
+    }
+
+    const planId = generatePlanId();
+    const now = getBenchmarkTime();
+    const planData = JSON.stringify(days);
+
+    database.query("INSERT INTO meal_plan (plan_id, created_at, plan_data) VALUES (?, ?, ?)").run(planId, now, planData);
+
+    return c.json({ success: true, plan_id: planId, created_at: now }, 201);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// App bootstrap
+// ---------------------------------------------------------------------------
+
+const app = createMockApp({
+  name: "smarthome",
+  port: 5003,
+  healthResponse: { ok: true, status: "healthy", service: "smarthome" },
+  routes: registerRoutes,
+});
+
+app.seed = () => {
+  initDatabase();
+};
+
+startServer(app);

--- a/mock-platform/mocks/smarthome/tsconfig.json
+++ b/mock-platform/mocks/smarthome/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/mock-platform/scripts/build-all.ts
+++ b/mock-platform/scripts/build-all.ts
@@ -90,6 +90,7 @@ async function verifyIsolation(results: BuildResult[]): Promise<{ violations: Ma
     shop: "/__mock_sentinel__/shop",
     todolist: "/__mock_sentinel__/todolist",
     "doc-search": "/__mock_sentinel__/doc-search",
+    smarthome: "/__mock_sentinel__/smarthome",
   };
 
   const successfulMocks = results.filter((r) => r.success);

--- a/mock-platform/scripts/build-task-images.ts
+++ b/mock-platform/scripts/build-task-images.ts
@@ -37,9 +37,10 @@ const BINARY_PORTS: Record<string, number> = {
   shop: 1234,
   todolist: 5002,
   "doc-search": 8123,
+  smarthome: 5003,
 };
 
-// All 30 benchmark task names (canonical source of truth)
+// All 34 benchmark task names (canonical source of truth)
 const ALL_TASK_NAMES = new Set([
   "watch-shop", "washer-shop", "info-change", "washer-change",
   "email-watch-shop", "email-washer-change", "email-writing", "email-reply",
@@ -51,6 +52,8 @@ const ALL_TASK_NAMES = new Set([
   "skill-conflict-resolution", "skill-dependency-fix", "noise-filtering",
   "mixed-tool-memory", "incremental-update-ctp", "live-web-research-sqlite-fts5",
   "conflict-repair-acb", "skill-combination",
+  "smart-home-thermostat", "grocery-reorder", "smart-home-morning-recovery", "grocery-budget-plan",
+  "smarthome_test",
 ]);
 
 interface AssetMapping {
@@ -252,6 +255,18 @@ function generateStartupScript(task: string, binaries: string[], startupExtra?: 
     lines.push("");
   }
 
+  // Step 0b: Data directory initialization for smarthome tasks
+  // The smarthome binary stores data at /var/lib/mock-data/smarthome/ and verifiers
+  // read from /tmp/mosi_smart_home.sqlite via symlink.
+  if (binaries.includes("smarthome")) {
+    lines.push("# Initialize smarthome data directory and verifier-compatible symlinks");
+    lines.push("mkdir -p /var/lib/mock-data/smarthome");
+    lines.push("chown mock:mock /var/lib/mock-data/smarthome");
+    lines.push("chmod 700 /var/lib/mock-data/smarthome");
+    lines.push("ln -sf /var/lib/mock-data/smarthome/smarthome.db /tmp/mosi_smart_home.sqlite");
+    lines.push("");
+  }
+
   // Binaries that are stubs (health/sentinel only) — the real services are
   // started by the task's startup.sh.  Implemented binaries (shop, doc-search)
   // are full Bun replacements and should be launched directly.
@@ -390,6 +405,17 @@ function generateStartupScript(task: string, binaries: string[], startupExtra?: 
     lines.push("fi");
     lines.push("");
   }
+  // python-fastapi: The following block was added to support tasks with binaries: []
+  // that still need to run startup.sh for Python FastAPI services. Now that smarthome
+  // tasks use Bun mock (binaries: ["smarthome"]), this block is no longer necessary
+  // for smarthome_test but is kept for potential future use.
+  // else if (binaries.length === 0) {
+  //   lines.push("# No mock binaries — check for task-specific startup.sh");
+  //   lines.push("if [ -f /workspace/environment/startup.sh ]; then");
+  //   lines.push("  bash /workspace/environment/startup.sh");
+  //   lines.push("fi");
+  //   lines.push("");
+  // }
 
   // Step 3: Final wait for all services to be ready
   if (implementedBinaries.length > 0 || startupExtra || hasStubBinaries) {

--- a/tasks/smarthome_test/environment/Dockerfile
+++ b/tasks/smarthome_test/environment/Dockerfile
@@ -1,0 +1,8 @@
+FROM liveclawbench-smarthome_test-base:latest
+
+COPY . /workspace/environment/
+
+# fastapi-required: Install smarthome-app dependencies (disabled when using Bun mock)
+# RUN cd /workspace/environment/smarthome-app/backend && pip install --no-cache-dir --break-system-packages -r requirements.txt
+
+CMD ["sh", "-c", "sleep infinity"]

--- a/tasks/smarthome_test/environment/seed.sql
+++ b/tasks/smarthome_test/environment/seed.sql
@@ -1,0 +1,50 @@
+-- Seed data for smart-home-thermostat task
+-- Focus: Thermostat control and room metrics
+
+-- Room
+INSERT INTO room (id, name) VALUES (1, 'Living Room');
+
+-- Room Metrics
+INSERT INTO room_metrics (id, temperature, humidity, unit_temp, noise, light, air_quality)
+VALUES (1, 72.5, 45.0, 'F', 35.0, 450.0, 85);
+
+-- Thermostat Settings (singleton)
+INSERT INTO thermostat_settings (id, mode, temperature, updated_at)
+VALUES (1, 'comfort', 72.0, '2026-05-06T08:00:00Z');
+
+-- Coffee Schedule (singleton)
+INSERT INTO coffee_schedule (id, start_time, updated_at)
+VALUES (1, '07:00', '2026-05-06T08:00:00Z');
+
+-- Benchmark Clock for deterministic time
+INSERT INTO benchmark_clock (id, clock_time)
+VALUES (1, '2026-05-06T08:30:00Z');
+
+-- Inventory (minimal for thermostat task)
+INSERT INTO inventory_item (item_name, quantity, unit, location, expiry_date, category) VALUES
+('Milk', 2.0, 'gallons', 'fridge', '2026-05-13', 'dairy'),
+('Bread', 1.0, 'loaf', 'pantry', '2026-05-10', 'bakery');
+
+-- Grocery Products (minimal)
+INSERT INTO grocery_product (product_id, name, price, stock_status) VALUES
+('PROD001', 'Organic Milk', 4.99, 'in_stock'),
+('PROD002', 'Whole Wheat Bread', 3.49, 'in_stock');
+
+-- Wearable/Recovery State
+INSERT INTO wearable_recovery_state (id, sleep_hours, sleep_score, readiness, resting_heart_rate)
+VALUES (1, 7.5, 85.0, 78.0, 62.0);
+
+-- Calendar Events
+INSERT INTO calendar_event (id, title, start_time, event_type, workout_type, updated_at) VALUES
+(1, 'Morning Workout', '2026-05-06T07:00:00Z', 'workout', 'yoga', '2026-05-06T08:00:00Z'),
+(2, 'Team Meeting', '2026-05-06T10:00:00Z', 'meeting', NULL, '2026-05-06T08:00:00Z');
+
+-- User Constraints
+INSERT INTO user_constraints (id, calorie_target, macro_targets, allergy_constraints, weekly_budget_limit)
+VALUES (1, 2000.0, '{"protein": 150, "carbs": 250, "fat": 65}', '[]', 150.0);
+
+-- Recipes
+INSERT INTO recipe (id, name, meal_type, ingredients, calories_total, allergens) VALUES
+(1, 'Oatmeal with Berries', 'breakfast', '["oats", "milk", "berries", "honey"]', 350.0, '["dairy"]'),
+(2, 'Grilled Chicken Salad', 'lunch', '["chicken", "lettuce", "tomato", "olive oil"]', 450.0, NULL),
+(3, 'Salmon with Vegetables', 'dinner', '["salmon", "broccoli", "carrots", "lemon"]', 550.0, '["fish"]');

--- a/tasks/smarthome_test/environment/startup.sh
+++ b/tasks/smarthome_test/environment/startup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Starting smarthome mock service..."
+
+# fastapi-required: Start the smarthome backend (disabled when using Bun mock)
+# cd /workspace/environment/smarthome-app/backend
+# python3 app.py &
+
+# Wait for service to be ready
+sleep 3
+
+echo "Smarthome mock service started on http://localhost:5003"

--- a/tasks/smarthome_test/instruction.md
+++ b/tasks/smarthome_test/instruction.md
@@ -1,0 +1,33 @@
+Please verify that the Smart Home mock environment is working correctly by performing the following tests:
+
+1. **Health Check**: Access http://localhost:5003/health and verify it returns a healthy status
+
+2. **Thermostat Test**:
+   - GET the current thermostat settings from /api/thermostat
+   - Change the thermostat mode to "eco" and temperature to 68°F via POST to /api/thermostat
+   - Verify the change persisted by GET /api/thermostat again
+
+3. **Coffee Schedule Test**:
+   - GET the current coffee schedule from /api/coffee-schedule
+   - Verify the status is derived correctly based on benchmark_clock
+
+4. **Inventory Test**:
+   - GET all inventory items from /api/inventory
+   - Add a new item "Eggs" with quantity 12, unit "pieces", location "fridge"
+   - Verify the item was added
+
+5. **Grocery Order Test**:
+   - GET available products from /api/grocery/products
+   - Create an order with 2 units of "PROD001" (Organic Milk)
+   - Verify the order was created with correct total
+
+6. **Calendar Test**:
+   - GET calendar events from /api/calendar
+   - Update the workout event (id=1) to change workout_type from "yoga" to "walking"
+   - Verify the update persisted
+
+7. **Meal Plan Test**:
+   - Create a 7-day meal plan using available recipes
+   - Verify the plan was saved and can be retrieved
+
+Report the results of each test.

--- a/tasks/smarthome_test/solution/solve.sh
+++ b/tasks/smarthome_test/solution/solve.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Reference solution: run openclaw agent with the task instruction
+openclaw agent --session-id "solve-smarthome-test" \
+    --timeout 120 \
+    --message "$(cat /workspace/instruction.md)"

--- a/tasks/smarthome_test/task.toml
+++ b/tasks/smarthome_test/task.toml
@@ -1,0 +1,30 @@
+version = "1.0"
+
+[metadata]
+difficulty = "easy"
+category = "test"
+tags = ["smarthome", "mock_verification"]
+
+domain = "Smart Home"
+domains_multi = ["Smart Home"]
+
+# Triple-Axis Complexity Factors (0 = absent, 1 = present)
+factor_a1 = 0   # Cross-Service Dependency
+factor_a2 = 0   # Contaminated Initial State
+factor_b1 = 0   # Implicit Goal Resolution
+factor_b2 = 0   # Knowledge System Maintenance
+
+case_id = 999   # Test case, not a real benchmark task
+
+[verifier]
+timeout_sec = 300.0
+
+[agent]
+timeout_sec = 600.0
+
+[environment]
+build_timeout_sec = 300.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 5120
+allow_internet = false

--- a/tasks/smarthome_test/tests/test.sh
+++ b/tasks/smarthome_test/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p /logs/verifier
+
+cd /workspace
+python3 /tests/verify.py 2>&1 | tee /tmp/verify_output.txt || true
+
+# Extract score from "Score: X.XX/1.0" pattern
+SCORE=$(grep -oP 'Score:\s*\K[0-9.]+' /tmp/verify_output.txt | tail -1 || echo "0")
+echo "$SCORE" > /logs/verifier/reward.txt

--- a/tasks/smarthome_test/tests/verify.py
+++ b/tasks/smarthome_test/tests/verify.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Verify smarthome_test task: comprehensive mock environment validation
+
+Tests all 8 domains of the Smart Home mock:
+1. Health endpoint
+2. Thermostat (GET/POST with persistence)
+3. Coffee Schedule (GET with derived status)
+4. Inventory (GET/POST/DELETE)
+5. Grocery Ordering (GET products, POST orders with transactions)
+6. Wearable/Recovery (GET)
+7. Calendar/Workout (GET/PUT with workout_type enum)
+8. Meal Planning (POST/GET with deterministic retrieval)
+"""
+
+import json
+import sqlite3
+import sys
+import tempfile
+import urllib.request
+import urllib.error
+
+# Configuration
+BASE_URL = "http://localhost:5003"
+DB_PATH = "/tmp/smarthome_test/smarthome.db"  # Default path, may be overridden by MOCK_DATA_DIR
+
+
+def http_request(method, path, data=None):
+    """Make HTTP request and return response"""
+    url = f"{BASE_URL}{path}"
+    headers = {"Content-Type": "application/json"} if data else {}
+
+    req = urllib.request.Request(url, method=method, headers=headers)
+    if data:
+        req.data = json.dumps(data).encode("utf-8")
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8")), response.status
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read().decode("utf-8")), e.code
+    except Exception as e:
+        return {"error": str(e)}, 0
+
+
+def test_health():
+    """Test 1: Health endpoint"""
+    print("\n=== Test 1: Health Endpoint ===")
+    resp, status = http_request("GET", "/health")
+
+    if status != 200:
+        print(f"FAIL: Health endpoint returned status {status}")
+        return 0.0
+
+    if resp.get("ok") != True or resp.get("service") != "smarthome":
+        print(f"FAIL: Invalid health response: {resp}")
+        return 0.0
+
+    print(f"PASS: Health endpoint OK - {resp}")
+    return 1.0
+
+
+def test_thermostat():
+    """Test 2: Thermostat GET/POST with persistence"""
+    print("\n=== Test 2: Thermostat ===")
+    score = 0.0
+
+    # GET initial state
+    resp, status = http_request("GET", "/api/thermostat")
+    if status != 200:
+        print(f"FAIL: GET thermostat returned {status}")
+        return 0.0
+
+    initial_mode = resp.get("mode")
+    initial_temp = resp.get("temperature")
+    print(f"Initial thermostat: mode={initial_mode}, temp={initial_temp}")
+    score += 0.3
+
+    # POST update
+    resp, status = http_request("POST", "/api/thermostat", {"mode": "eco", "temperature": 68})
+    if status != 200:
+        print(f"FAIL: POST thermostat returned {status}: {resp}")
+        return score
+
+    if resp.get("mode") != "eco" or resp.get("temperature") != 68:
+        print(f"FAIL: POST response incorrect: {resp}")
+        return score
+
+    # Verify benchmark time is used (not current wall clock)
+    updated_at = resp.get("updated_at")
+    if isinstance(updated_at, str) and "T" in updated_at and ":" in updated_at:
+        # Should be ISO format like "2026-05-06T08:30:00Z", not "HH:MM:SS"
+        if updated_at.count(":") == 2 and "T" in updated_at:
+            print(f"PASS: updated_at uses benchmark time: {updated_at}")
+            score += 0.3
+        else:
+            print(f"WARN: updated_at may not be benchmark time: {updated_at}")
+    else:
+        print(f"FAIL: updated_at is missing or not a valid ISO string: {updated_at}")
+
+    print(f"POST thermostat: {resp}")
+    score += 0.2
+
+    # GET again to verify persistence
+    resp, status = http_request("GET", "/api/thermostat")
+    if resp.get("mode") == "eco" and resp.get("temperature") == 68:
+        print(f"PASS: Thermostat update persisted")
+        score += 0.2
+    else:
+        print(f"FAIL: Thermostat update not persisted: {resp}")
+
+    return min(score, 1.0)
+
+
+def test_coffee_schedule():
+    """Test 3: Coffee Schedule with derived status"""
+    print("\n=== Test 3: Coffee Schedule ===")
+    score = 0.0
+
+    resp, status = http_request("GET", "/api/coffee-schedule")
+    if status != 200:
+        print(f"FAIL: GET coffee-schedule returned {status}")
+        return 0.0
+
+    start_time = resp.get("start_time")
+    status_val = resp.get("status")
+
+    if not start_time or not status_val:
+        print(f"FAIL: Missing fields in response: {resp}")
+        return 0.0
+
+    print(f"Coffee schedule: start_time={start_time}, status={status_val}")
+    score += 0.5
+
+    # Status should be derived from benchmark_clock
+    valid_statuses = ["scheduled", "preparing", "brewing", "ready"]
+    if status_val in valid_statuses:
+        print(f"PASS: Status is valid derived value: {status_val}")
+        score += 0.5
+    else:
+        print(f"FAIL: Invalid status: {status_val}")
+
+    return score
+
+
+def test_inventory():
+    """Test 4: Inventory CRUD"""
+    print("\n=== Test 4: Inventory ===")
+    score = 0.0
+
+    # GET initial inventory
+    resp, status = http_request("GET", "/api/inventory")
+    if status != 200:
+        print(f"FAIL: GET inventory returned {status}")
+        return 0.0
+
+    initial_count = len(resp)
+    print(f"Initial inventory count: {initial_count}")
+    score += 0.3
+
+    # POST new item
+    new_item = {"item_name": "Test Eggs", "quantity": 12, "unit": "pieces", "location": "fridge"}
+    resp, status = http_request("POST", "/api/inventory", new_item)
+    if status not in [200, 201]:
+        print(f"FAIL: POST inventory returned {status}: {resp}")
+        return score
+
+    item_id = resp.get("id")
+    print(f"Added item with id={item_id}: {resp}")
+    score += 0.3
+
+    # Verify added
+    resp, status = http_request("GET", "/api/inventory")
+    if len(resp) == initial_count + 1:
+        print(f"PASS: Item count increased by 1")
+        score += 0.2
+    else:
+        print(f"FAIL: Item count not increased: {len(resp)}")
+
+    # DELETE item
+    resp, status = http_request("DELETE", f"/api/inventory/{item_id}")
+    if status == 200:
+        print(f"PASS: Deleted item {item_id}")
+        score += 0.2
+    else:
+        print(f"WARN: DELETE returned {status}")
+
+    return min(score, 1.0)
+
+
+def test_grocery():
+    """Test 5: Grocery Ordering"""
+    print("\n=== Test 5: Grocery Ordering ===")
+    score = 0.0
+
+    # GET products
+    resp, status = http_request("GET", "/api/grocery/products")
+    if status != 200:
+        print(f"FAIL: GET products returned {status}")
+        return 0.0
+
+    products = resp
+    print(f"Found {len(products)} products")
+    score += 0.3
+
+    # POST order
+    order = {"items": [{"product_id": "PROD001", "quantity": 2}]}
+    resp, status = http_request("POST", "/api/grocery/orders", order)
+    if status not in [200, 201]:
+        print(f"FAIL: POST order returned {status}: {resp}")
+        return score
+
+    order_id = resp.get("order_id")
+    total = resp.get("total")
+    print(f"Created order: {order_id}, total={total}")
+    score += 0.4
+
+    # Verify total (PROD001 = Organic Milk at $4.99 * 2 = $9.98)
+    if total and abs(total - 9.98) < 0.01:
+        print(f"PASS: Order total correct: {total}")
+        score += 0.3
+    else:
+        print(f"WARN: Order total may be incorrect: {total}")
+
+    return min(score, 1.0)
+
+
+def test_wearable():
+    """Test 6: Wearable/Recovery"""
+    print("\n=== Test 6: Wearable/Recovery ===")
+
+    resp, status = http_request("GET", "/api/wearable-recovery")
+    if status != 200:
+        print(f"FAIL: GET wearable-recovery returned {status}")
+        return 0.0
+
+    required_fields = ["sleep_hours", "sleep_score", "readiness", "resting_heart_rate"]
+    missing = [f for f in required_fields if f not in resp]
+
+    if missing:
+        print(f"FAIL: Missing fields: {missing}")
+        return 0.0
+
+    print(f"Wearable data: {resp}")
+    print(f"PASS: All wearable fields present")
+    return 1.0
+
+
+def test_calendar():
+    """Test 7: Calendar/Workout"""
+    print("\n=== Test 7: Calendar/Workout ===")
+    score = 0.0
+
+    # GET events
+    resp, status = http_request("GET", "/api/calendar")
+    if status != 200:
+        print(f"FAIL: GET calendar returned {status}")
+        return 0.0
+
+    events = resp
+    print(f"Found {len(events)} calendar events")
+    score += 0.3
+
+    # Find workout event
+    workout_event = next((e for e in events if e.get("workout_type")), None)
+    if not workout_event:
+        print(f"WARN: No workout event found")
+        return score
+
+    event_id = workout_event.get("id")
+    original_type = workout_event.get("workout_type")
+    print(f"Workout event: id={event_id}, workout_type={original_type}")
+    score += 0.2
+
+    # PUT update workout_type
+    resp, status = http_request("PUT", f"/api/calendar/{event_id}", {"workout_type": "walking"})
+    if status != 200:
+        print(f"FAIL: PUT calendar returned {status}: {resp}")
+        return score
+
+    if resp.get("workout_type") == "walking":
+        print(f"PASS: Workout type updated to walking")
+        score += 0.3
+    else:
+        print(f"FAIL: Workout type not updated: {resp}")
+
+    # Verify persistence
+    resp, status = http_request("GET", f"/api/calendar/{event_id}")
+    if resp.get("workout_type") == "walking":
+        print(f"PASS: Workout update persisted")
+        score += 0.2
+    else:
+        print(f"WARN: Workout update may not persist: {resp}")
+
+    return min(score, 1.0)
+
+
+def test_meal_plan():
+    """Test 8: Meal Planning"""
+    print("\n=== Test 8: Meal Planning ===")
+    score = 0.0
+
+    # GET recipes first
+    resp, status = http_request("GET", "/api/recipes")
+    if status != 200:
+        print(f"FAIL: GET recipes returned {status}")
+        return 0.0
+
+    recipes = resp
+    print(f"Found {len(recipes)} recipes")
+    score += 0.2
+
+    # Create 7-day meal plan
+    days = []
+    for i in range(7):
+        day = {
+            "date": f"2026-05-{7+i:02d}",
+            "meals": [
+                {"meal_type": "breakfast", "meal_id": 1},
+                {"meal_type": "lunch", "meal_id": 2},
+                {"meal_type": "dinner", "meal_id": 3}
+            ]
+        }
+        days.append(day)
+
+    resp, status = http_request("POST", "/api/meal-plan", {"days": days})
+    if status not in [200, 201]:
+        print(f"FAIL: POST meal-plan returned {status}: {resp}")
+        return score
+
+    plan_id = resp.get("plan_id")
+    created_at = resp.get("created_at")
+    print(f"Created meal plan: {plan_id}, created_at={created_at}")
+    score += 0.4
+
+    # Verify benchmark time used
+    if isinstance(created_at, str) and "T" in created_at:
+        print(f"PASS: created_at uses benchmark time: {created_at}")
+        score += 0.2
+    else:
+        print(f"FAIL: created_at is missing or not a valid ISO string: {created_at}")
+
+    # GET meal plan
+    resp, status = http_request("GET", "/api/meal-plan")
+    if status != 200:
+        print(f"FAIL: GET meal-plan returned {status}")
+        return score
+
+    if resp.get("plan_id") == plan_id:
+        print(f"PASS: Meal plan retrieved correctly")
+        score += 0.2
+    else:
+        print(f"WARN: Retrieved plan_id mismatch")
+
+    return min(score, 1.0)
+
+
+def main():
+    print("=" * 60)
+    print("Smart Home Mock Environment Verification")
+    print("=" * 60)
+
+    tests = [
+        ("Health", test_health),
+        ("Thermostat", test_thermostat),
+        ("Coffee Schedule", test_coffee_schedule),
+        ("Inventory", test_inventory),
+        ("Grocery", test_grocery),
+        ("Wearable", test_wearable),
+        ("Calendar", test_calendar),
+        ("Meal Plan", test_meal_plan),
+    ]
+
+    results = []
+    for name, test_func in tests:
+        try:
+            score = test_func()
+            results.append((name, score))
+        except Exception as e:
+            print(f"ERROR in {name}: {e}")
+            results.append((name, 0.0))
+
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+
+    total_score = 0.0
+    for name, score in results:
+        status = "PASS" if score >= 0.8 else "PARTIAL" if score >= 0.5 else "FAIL"
+        print(f"  {name}: {score:.2f} [{status}]")
+        total_score += score
+
+    final_score = total_score / len(tests)
+    print(f"\nFinal Score: {final_score:.2f}/1.0")
+
+    print(f"Score: {final_score:.2f}/1.0")
+    sys.exit(0 if final_score >= 0.8 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Mock Service (mock-platform/mocks/smarthome/)

- Add Bun mock implementation with 8 domain APIs:
  - Room Metrics (read-only)
  - Thermostat (GET/POST)
  - Coffee Schedule (GET/POST with derived status)
  - Inventory (GET/POST/DELETE)
  - Grocery Ordering (GET products, POST orders)
  - Wearable/Recovery (read-only)
  - Calendar/Workout (GET/PUT)
  - Meal Planning (GET constraints/recipes, POST/GET meal-plan)
- SQLite persistence with benchmark time determinism
- Seed SQL initialization for test data

## Verification Task (tasks/smarthome_test/)

- Harbor-format task to verify smarthome mock correctness
- Tests all 8 APIs with benchmark time verification
- Validates thermostat/coffee-schedule state updates
- Verifies inventory CRUD and grocery ordering
- Checks wearable data and calendar workout updates
- Validates meal plan creation with deterministic IDs

## Configuration Updates

- Add smarthome to binaries list in task-binary-map.json
- Add smarthome_test task with seed.sql asset
- Update build-all.ts and build-task-images.ts for smarthome support