### PR TITLE
Add AgentBay bridge docs and runner

### DIFF
--- a/agentbay/.gitignore
+++ b/agentbay/.gitignore
@@ -1,0 +1,2 @@
+image_lock.toml
+*.private.toml

--- a/agentbay/README.md
+++ b/agentbay/README.md
@@ -1,0 +1,96 @@
+# LiveClawBench on AgentBay
+
+This directory contains the public bridge between LiveClawBench tasks and
+Harbor's AgentBay environment backend. It intentionally does not contain real
+`imgc-*` image IDs; those belong to the account that built and activated the
+AgentBay images.
+
+## Install Harbor with AgentBay Support
+
+`setup.sh` installs Harbor into the local `.venv`. To include the AgentBay SDK,
+pass Harbor extras during setup:
+
+```bash
+HARBOR_EXTRAS=agentbay ./setup.sh
+```
+
+Until the AgentBay backend is released in a tag, install from the PR branch or
+commit that contains it:
+
+```bash
+HARBOR_VERSION=agentbay-environment HARBOR_EXTRAS=agentbay ./setup.sh
+```
+
+## Image Lock Model
+
+Harbor receives a task environment directory such as:
+
+```text
+tasks/watch-shop/environment
+```
+
+The AgentBay backend hashes the sorted file contents under that directory and
+uses the first 12 hex characters as `env_hash12`. The reproducible lookup key is:
+
+```text
+liveclawbench/<task-name>/<env_hash12>
+```
+
+`prebuild=true` requires `agentbay/image_lock.toml` to contain a ready entry for
+that exact task/hash. This prevents a large run from silently falling back to a
+different image or to runtime environment upload.
+
+Copy the example lock and fill it with active images:
+
+```bash
+cp agentbay/image_lock.example.toml agentbay/image_lock.toml
+```
+
+Each real entry should look like:
+
+```toml
+[images."liveclawbench/<task>/<env_hash12>"]
+agentbay_image_id = "imgc-..."
+activated = true
+benchmark = "liveclawbench"
+task = "<task>"
+env_hash12 = "<env_hash12>"
+environment_baked = true
+skip_environment_upload = true
+skip_setup = true
+workdir = "/workspace"
+entrypoint = ""
+```
+
+## Running Locally vs AgentBay
+
+Local Docker remains the default path:
+
+```bash
+bash scripts/run_dataset.sh
+```
+
+AgentBay uses the same dataset registry, agent, model credentials, and judge
+settings, but swaps the environment backend and image source:
+
+```bash
+bash scripts/run_agentbay_dataset.sh
+```
+
+Required environment variables:
+
+```bash
+export AGENTBAY_API_KEY="..."
+export OPENAI_BASE_URL="https://your-openai-compatible-endpoint/v1"
+export OPENAI_API_KEY="..."
+export JUDGE_MODEL_ID="deepseek-v3.2"
+```
+
+`scripts/run_agentbay_dataset.sh` derives `JUDGE_BASE_URL` and `JUDGE_API_KEY`
+from `OPENAI_BASE_URL` and `OPENAI_API_KEY` unless they are already set. The
+script passes judge variables through `env_passthrough` so they are visible
+inside AgentBay verifier commands without writing secrets into the lock file.
+
+The AgentBay backend creates one session per Harbor trial. With 30 active task
+images, `--n-concurrent 30` can start one session per task in the first wave;
+actual capacity is controlled by the AgentBay account and policy.

--- a/agentbay/image_lock.example.toml
+++ b/agentbay/image_lock.example.toml
@@ -1,0 +1,17 @@
+# Example AgentBay image lock for LiveClawBench.
+#
+# Copy this file to agentbay/image_lock.toml and replace placeholders with
+# image IDs that are active in your AgentBay account. The real lock is ignored
+# by git because it is account- and environment-specific.
+
+[images."liveclawbench/watch-shop/ffffffffffff"]
+agentbay_image_id = "imgc-xxxxxxxxxxxxxxxxx"
+activated = true
+benchmark = "liveclawbench"
+task = "watch-shop"
+env_hash12 = "ffffffffffff"
+environment_baked = true
+skip_environment_upload = true
+skip_setup = true
+workdir = "/workspace"
+entrypoint = ""

--- a/scripts/run_agentbay_dataset.sh
+++ b/scripts/run_agentbay_dataset.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run LiveClawBench using Harbor's AgentBay environment backend.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+HARBOR_BIN="${HARBOR_BIN:-.venv/bin/harbor}"
+IMAGE_LOCK_PATH="${IMAGE_LOCK_PATH:-agentbay/image_lock.toml}"
+MODEL="${MODEL:-moonshot/kimi-k2.5}"
+DATASET_VERSION="${DATASET_VERSION:-0.1.0}"
+N_CONCURRENT="${N_CONCURRENT:-30}"
+N_ATTEMPTS="${N_ATTEMPTS:-3}"
+TIMEOUT_MULTIPLIER="${TIMEOUT_MULTIPLIER:-2.0}"
+JOBS_DIR="${JOBS_DIR:-jobs}"
+CUSTOM_REASONING="${CUSTOM_REASONING:-true}"
+ENV_PASSTHROUGH="${ENV_PASSTHROUGH:-JUDGE_BASE_URL,JUDGE_API_KEY,JUDGE_MODEL_ID}"
+
+OPENAI_BASE_URL="${OPENAI_BASE_URL:-${CUSTOM_BASE_URL:-}}"
+OPENAI_API_KEY="${OPENAI_API_KEY:-${CUSTOM_API_KEY:-}}"
+JUDGE_BASE_URL="${JUDGE_BASE_URL:-$OPENAI_BASE_URL}"
+JUDGE_API_KEY="${JUDGE_API_KEY:-$OPENAI_API_KEY}"
+JUDGE_MODEL_ID="${JUDGE_MODEL_ID:-deepseek-v3.2}"
+
+if [ ! -x "$HARBOR_BIN" ]; then
+    echo "ERROR: Harbor binary not found at $HARBOR_BIN. Run ./setup.sh first." >&2
+    exit 1
+fi
+
+if [ ! -f "$IMAGE_LOCK_PATH" ]; then
+    echo "ERROR: AgentBay image lock not found: $IMAGE_LOCK_PATH" >&2
+    echo "Copy agentbay/image_lock.example.toml to agentbay/image_lock.toml and fill active imgc IDs." >&2
+    exit 1
+fi
+
+if [ -z "${AGENTBAY_API_KEY:-}" ]; then
+    echo "ERROR: AGENTBAY_API_KEY is required for --env agentbay." >&2
+    exit 1
+fi
+
+if [ -z "$OPENAI_BASE_URL" ] || [ -z "$OPENAI_API_KEY" ]; then
+    echo "ERROR: OPENAI_BASE_URL and OPENAI_API_KEY are required for the OpenClaw custom endpoint." >&2
+    exit 1
+fi
+
+export AGENTBAY_API_KEY
+export JUDGE_BASE_URL
+export JUDGE_API_KEY
+export JUDGE_MODEL_ID
+
+"$HARBOR_BIN" run --dataset "liveclawbench@$DATASET_VERSION" \
+  --registry-path ./registry.json \
+  -a openclaw \
+  -m "$MODEL" \
+  --n-concurrent "$N_CONCURRENT" \
+  --n-attempts "$N_ATTEMPTS" \
+  -o "$JOBS_DIR" \
+  --ae "CUSTOM_BASE_URL=$OPENAI_BASE_URL" \
+  --ae "CUSTOM_API_KEY=$OPENAI_API_KEY" \
+  --ae "CUSTOM_REASONING=$CUSTOM_REASONING" \
+  --timeout-multiplier "$TIMEOUT_MULTIPLIER" \
+  --env agentbay \
+  --environment-kwarg "image_lock_path=$IMAGE_LOCK_PATH" \
+  --environment-kwarg benchmark_name=liveclawbench \
+  --environment-kwarg prebuild=true \
+  --environment-kwarg "env_passthrough=$ENV_PASSTHROUGH"

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,9 @@
 # Run from the LiveClawBench/ directory.
 set -euo pipefail
 
-HARBOR_REPO_URL="https://github.com/Mosi-AI/claw-harbor.git"
-HARBOR_VERSION="v0.1.0"
+HARBOR_REPO_URL="${HARBOR_REPO_URL:-https://github.com/Mosi-AI/claw-harbor.git}"
+HARBOR_VERSION="${HARBOR_VERSION:-v0.1.0}"
+HARBOR_EXTRAS="${HARBOR_EXTRAS:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 
@@ -69,8 +70,14 @@ else
     echo "  Virtual environment .venv already exists — skipping creation."
 fi
 
-echo "  Installing harbor CLI from $HARBOR_REPO_URL @ $HARBOR_VERSION ..."
-uv pip install --quiet --python "$VENV_DIR/bin/python" "harbor @ git+${HARBOR_REPO_URL}@${HARBOR_VERSION}"
+if [ -n "$HARBOR_EXTRAS" ]; then
+    HARBOR_SPEC="harbor[$HARBOR_EXTRAS] @ git+${HARBOR_REPO_URL}@${HARBOR_VERSION}"
+    echo "  Installing harbor CLI from $HARBOR_REPO_URL @ $HARBOR_VERSION with extras: $HARBOR_EXTRAS ..."
+else
+    HARBOR_SPEC="harbor @ git+${HARBOR_REPO_URL}@${HARBOR_VERSION}"
+    echo "  Installing harbor CLI from $HARBOR_REPO_URL @ $HARBOR_VERSION ..."
+fi
+uv pip install --quiet --python "$VENV_DIR/bin/python" "$HARBOR_SPEC"
 
 HARBOR_BIN="$VENV_DIR/bin/harbor"
 if [ ! -f "$HARBOR_BIN" ]; then


### PR DESCRIPTION
## Summary
- add a dataset-owned AgentBay bridge under `agentbay/` with public docs and an example image lock
- add `scripts/run_agentbay_dataset.sh` as the canonical LiveClawBench AgentBay prebuild entry
- let `setup.sh` install Harbor extras via `HARBOR_EXTRAS=agentbay` and override the Harbor ref with `HARBOR_VERSION`

## Scope
- no real `imgc-*` IDs, ACR refs, API keys, or private image locks are committed
- assumes the Harbor AgentBay backend from Mosi-AI/claw-harbor#12
- keeps benchmark task directories unchanged

## Tests
- `bash -n setup.sh scripts/run_agentbay_dataset.sh`
- `AGENTBAY_API_KEY=test OPENAI_BASE_URL=https://example.com/v1 OPENAI_API_KEY=sk-test HARBOR_BIN=/usr/bin/true IMAGE_LOCK_PATH=agentbay/image_lock.example.toml bash scripts/run_agentbay_dataset.sh`
- `git diff --check`