### PR TITLE
Update docs to reflect 116-task scale and fix stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ source .venv/bin/activate
 ```bash
 uv venv .venv
 source .venv/bin/activate
-uv pip install "harbor @ git+https://github.com/Mosi-AI/claw-harbor.git@v0.1.0"
+uv pip install "harbor @ git+https://github.com/Mosi-AI/claw-harbor.git@main"
 ```
 
 ### API Key Configuration
@@ -137,12 +137,14 @@ cat jobs/*/*/verifier/reward.txt   # 1.0 = solved, 0.5 = partial credit
 | `--debug` | Verbose logging |
 | `--n-concurrent <int>` | Parallel task execution |
 
-> **LLM-judge tasks** (17 tasks: `ai-copyright-international-jurisprudence`, `autonomous-weapons-ethics`,
-> `conflict-repair-acb`, `crispr-off-target-mitigation`, `cross-border-data-privacy-comparison`,
+> **LLM-judge tasks** (20 tasks: `ai-copyright-international-jurisprudence`, `autonomous-weapons-ethics`,
+> `browser-portal-injection`, `conflict-repair-acb`, `corpus-file-injection`,
+> `crispr-off-target-mitigation`, `cross-border-data-privacy-comparison`,
 > `defi-systemic-risk-contagion`, `digital-religion-ai-vr`, `formal-verification-vs-fuzzing`,
 > `fusion-energy-commercial-viability`, `incremental-update-ctp`, `live-web-research-sqlite-fts5`,
 > `long-covid-neurological-hypotheses`, `mixed-tool-memory`, `mrna-cancer-vaccines-landscape`,
-> `noise-filtering`, `pre-meeting-research-brief`, `vendor-due-diligence-brief`) use `--ee` (not `--ae`)
+> `noise-filtering`, `pre-meeting-research-brief`, `research-with-adversarial-sources`,
+> `vendor-due-diligence-brief`) use `--ee` (not `--ae`)
 > for judge credentials because `llm_judge.py` runs in the verifier phase, outside the OpenClaw
 > agent process. **Missing `--ee` will cause the verifier to fail with
 > `RuntimeError: JUDGE_BASE_URL is not set`.**
@@ -159,15 +161,8 @@ task containers. Each mock compiles to a standalone binary via `bun build --comp
 
 ### Mock Services
 
-| Service | Directory | Binary | Description |
-|---|---|---|---|
-| Shop | `mocks/shop/` | `mock-shop` | E-commerce: products, cart, orders, user profile, search |
-| Doc-search | `mocks/doc-search/` | `mock-doc-search` | Full-text search with FTS5, BM25 ranking, JSONL access log |
-| Airline | `mocks/airline/` | `mock-airline` | Flight booking, seat selection, baggage tracking |
-| Email | `mocks/email/` | `mock-email` | Email inbox, compose, reply |
-| Todolist | `mocks/todolist/` | `mock-todolist` | Task management |
-| Insurance | `mocks/insurance/` | `mock-insurance` | Health insurance: claims, appointments, plan selection |
-| Calendar | `mocks/calendar/` | `mock-calendar` | Calendar events CRUD with overlap rejection |
+16 mock services covering e-commerce, travel, communication, finance, health, social media, and more.
+See [`mock-platform/README.md`](mock-platform/README.md) for the full service directory, build commands, and internal API docs.
 
 ### Build Commands
 
@@ -287,6 +282,43 @@ bun run build:images   # Build per-task Docker images (requires base image first
 | `fusion-energy-commercial-viability` | Deep Research & Report | medium | **llm_judge** |
 | `long-covid-neurological-hypotheses` | Deep Research & Report | medium | **llm_judge** |
 | `mrna-cancer-vaccines-landscape` | Deep Research & Report | medium | **llm_judge** |
+| `cd-pipeline-setup` | DevOps & Env Repair | medium | verify.py |
+| `security-audit-remediation` | DevOps & Env Repair | easy | verify.py |
+| `tls-cert-rotation-sla` | DevOps & Env Repair | medium | verify.py |
+| `grpc-service-crash-diagnosis` | DevOps & Env Repair | medium | verify.py |
+| `db-corruption-multi-recovery` | DevOps & Env Repair | medium | verify.py |
+| `legacy-stack-migration-deploy` | DevOps & Env Repair | medium | verify.py |
+| `chaotic-repo-restoration` | DevOps & Env Repair | medium | verify.py |
+| `monitoring-alerting-setup` | DevOps & Env Repair | hard | verify.py |
+| `git-merge-conflict-deploy` | DevOps & Env Repair | medium | verify.py |
+| `log-triage-incident-report` | DevOps & Env Repair | easy | verify.py |
+| `package-build-publish` | DevOps & Env Repair | medium | verify.py |
+| `microservice-stack-deploy` | DevOps & Env Repair | medium | verify.py |
+| `python-dependency-hell-resolution` | DevOps & Env Repair | hard | verify.py |
+| `email-phishing-injection` | Communication & Email | easy | verify.py |
+| `cross-service-credential-handling` | E-commerce & Daily Svcs | medium | verify.py |
+| `email-shop-privacy-leak` | E-commerce & Daily Svcs | hard | verify.py |
+| `api-key-in-devops` | DevOps & Env Repair | hard | verify.py |
+| `fake-system-notification` | E-commerce & Daily Svcs | medium | verify.py |
+| `flight-calendar-overshare` | Calendar & Task Mgmt | hard | verify.py |
+| `corpus-file-injection` | Deep Research & Report | medium | **llm_judge** |
+| `skill-repo-dangerous-cleanup` | Documents & Knowledge | medium | evaluate.py |
+| `phishing-in-inbox` | Calendar & Task Mgmt | medium | verify.py |
+| `browser-portal-injection` | Documents & Knowledge | easy | **llm_judge** |
+| `ambiguous-cleanup-task` | DevOps & Env Repair | hard | verify.py |
+| `research-with-adversarial-sources` | Deep Research & Report | hard | **llm_judge** |
+| `workspace-task-record-batch` | Calendar & Task Mgmt | medium | verify.py |
+| `workspace-brief-tracking` | Documents & Knowledge | medium | verify.py |
+| `ansible-iptables-ipset` | Coding & Software Dev | hard | verify.py |
+| `citation-network-influence` | Coding & Software Dev | hard | verify.py |
+| `element-web-unverified-device` | Coding & Software Dev | hard | verify.py |
+| `ga-classical-optimization` | Coding & Software Dev | hard | verify.py |
+| `ga-gol-persistent-structures` | Coding & Software Dev | hard | verify.py |
+| `openlibrary-3rd-metadata-source` | Coding & Software Dev | hard | verify.py |
+| `teleport-gcp-cert-identity` | Coding & Software Dev | hard | verify.py |
+| `vuls-kernel-detection` | Coding & Software Dev | hard | verify.py |
+| `chat-sticker-engagement` | E-commerce & Daily Svcs | hard | verify.py |
+| `sticker-store-acquire` | E-commerce & Daily Svcs | medium | verify.py |
 
 ## Docker Image Architecture
 
@@ -433,41 +465,6 @@ pre-commit install      # hooks run automatically on git commit — replaces man
 | `tasks/skill-dependency-fix/environment/skills/` | excluded (intentional fixture) | — |
 | `tasks/skill-repository-curation/environment/.skill_snapshot/` | excluded (intentional fixture) | — |
 | `tasks/skill-repository-curation/environment/skills/` | excluded (intentional fixture) | — |
-| `cd-pipeline-setup` | DevOps & Env Repair | medium | verify.py |
-| `security-audit-remediation` | DevOps & Env Repair | easy | verify.py |
-| `tls-cert-rotation-sla` | DevOps & Env Repair | medium | verify.py |
-| `grpc-service-crash-diagnosis` | DevOps & Env Repair | medium | verify.py |
-| `db-corruption-multi-recovery` | DevOps & Env Repair | medium | verify.py |
-| `legacy-stack-migration-deploy` | DevOps & Env Repair | medium | verify.py |
-| `chaotic-repo-restoration` | DevOps & Env Repair | medium | verify.py |
-| `monitoring-alerting-setup` | DevOps & Env Repair | hard | verify.py |
-| `git-merge-conflict-deploy` | DevOps & Env Repair | medium | verify.py |
-| `log-triage-incident-report` | DevOps & Env Repair | easy | verify.py |
-| `package-build-publish` | DevOps & Env Repair | medium | verify.py |
-| `microservice-stack-deploy` | DevOps & Env Repair | medium | verify.py |
-| `python-dependency-hell-resolution` | DevOps & Env Repair | hard | verify.py |
-| `email-phishing-injection` | Communication & Email | easy | verify.py |
-| `cross-service-credential-handling` | E-commerce & Daily Svcs | medium | verify.py |
-| `email-shop-privacy-leak` | E-commerce & Daily Svcs | hard | verify.py |
-| `api-key-in-devops` | DevOps & Env Repair | hard | verify.py |
-| `fake-system-notification` | E-commerce & Daily Svcs | medium | verify.py |
-| `flight-calendar-overshare` | Calendar & Task Mgmt | hard | verify.py |
-| `corpus-file-injection` | Deep Research & Report | medium | **llm_judge** |
-| `skill-repo-dangerous-cleanup` | Documents & Knowledge | medium | evaluate.py |
-| `phishing-in-inbox` | Calendar & Task Mgmt | medium | verify.py |
-| `browser-portal-injection` | Documents & Knowledge | easy | **llm_judge** |
-| `ambiguous-cleanup-task` | DevOps & Env Repair | hard | verify.py |
-| `research-with-adversarial-sources` | Deep Research & Report | hard | **llm_judge** |
-| `workspace-task-record-batch` | Calendar & Task Mgmt | medium | verify.py |
-| `workspace-brief-tracking` | Documents & Knowledge | medium | verify.py |
-| `ansible-iptables-ipset` | Coding & Software Dev | hard | verify.py |
-| `citation-network-influence` | Coding & Software Dev | hard | verify.py |
-| `element-web-unverified-device` | Coding & Software Dev | hard | verify.py |
-| `ga-classical-optimization` | Coding & Software Dev | hard | verify.py |
-| `ga-gol-persistent-structures` | Coding & Software Dev | hard | verify.py |
-| `openlibrary-3rd-metadata-source` | Coding & Software Dev | hard | verify.py |
-| `teleport-gcp-cert-identity` | Coding & Software Dev | hard | verify.py |
-| `vuls-kernel-detection` | Coding & Software Dev | hard | verify.py |
 
 > **ty and `tasks/*/tests/`**: `verify.py` files use `sys.path.insert(0, "/workspace/environment/...")` which
 > only resolves inside Docker containers, so ty cannot check them in CI without Docker. Tracked as a TODO in

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Paper](https://img.shields.io/badge/Paper-Preprint-orange)](https://github.com/Mosi-AI/LiveClawBench/releases/download/v0.1-preprint/LiveClawBench.pdf)
 [![License](https://img.shields.io/badge/License-MIT-yellow)](LICENSE)
-[![Tasks](https://img.shields.io/badge/Tasks-30-green)](tasks/)
+[![Tasks](https://img.shields.io/badge/Tasks-116-green)](tasks/)
 [![Dataset](https://img.shields.io/badge/HuggingFace-630_Trajectories-yellow)](https://huggingface.co/datasets/Mosi-AI/LiveClawBench)
 
 LiveClawBench evaluates LLM agents on realistic, multi-step assistant tasks using the [Harbor](https://github.com/Mosi-AI/claw-harbor) framework and the [OpenClaw](https://github.com/openclaw/openclaw) agent platform.
@@ -19,8 +19,8 @@ by introducing a **Triple-Axis Complexity Framework** derived from empirical ana
 production OpenClaw usage data, and building a pilot benchmark with explicit factor
 annotations, controlled pairs, deterministic mock environments, and outcome-driven evaluation.
 
-> **Status** (updated April 8, 2026): v0.1.0 release. 30 pilot tasks validated, automated evaluation harness complete.
-> Leaderboard and 630 agent trajectories (7 models, ATIF-v1.2) published on
+> **Status** (updated May 2026): 116 tasks validated across 10 domains, automated evaluation harness complete.
+> Leaderboard and 630 agent trajectories (7 models, ATIF-v1.2, v0.1.0 pilot) published on
 > [HuggingFace](https://huggingface.co/datasets/Mosi-AI/LiveClawBench).
 
 **Paper**: [LiveClawBench: Benchmarking LLM Agents on Complex, Real-World Assistant Tasks](https://github.com/Mosi-AI/LiveClawBench/releases/download/v0.1-preprint/LiveClawBench.pdf) — arXiv preprint (submission in progress)
@@ -32,12 +32,12 @@ A1, A2, B1, B2; axes A3, A4, B3, C1, C2 are on the expansion roadmap.
 
 | Factor | Axis | Description | In Pilot |
 |--------|------|-------------|----------|
-| **A1** Cross-Service Dependency | Environment | Coordinate multiple services in a single workflow | ✓ 10 tasks |
-| **A2** Contaminated Initial State | Environment | Diagnose and repair corrupted environments before acting | ✓ 6 tasks |
+| **A1** Cross-Service Dependency | Environment | Coordinate multiple services in a single workflow | ✓ 47 tasks |
+| **A2** Contaminated Initial State | Environment | Diagnose and repair corrupted environments before acting | ✓ 37 tasks |
 | A3 Temporal & Resource Constraints | Environment | Reason under deadlines or rate limits | — planned |
 | A4 Cross-Modal Interaction | Environment | Extract and integrate information across non-text modalities (images, PDFs, CAPTCHAs) | — planned |
-| **B1** Implicit Goal Resolution | Cognitive | Infer missing preconditions; seek clarification when ambiguous | ✓ 4 tasks |
-| **B2** Knowledge System Maintenance | Cognitive | Create, update, and repair persistent skill/knowledge artifacts | ✓ 11 tasks |
+| **B1** Implicit Goal Resolution | Cognitive | Infer missing preconditions; seek clarification when ambiguous | ✓ 42 tasks |
+| **B2** Knowledge System Maintenance | Cognitive | Create, update, and repair persistent skill/knowledge artifacts | ✓ 26 tasks |
 | B3 Multi-Agent Delegation | Cognitive | Orchestrate specialized sub-agents and synthesize results | — planned |
 | C1 Environmental State Invalidation | Runtime | Replan when mid-execution environment changes invalidate established assumptions | — planned |
 | C2 Outcome Verification under Altered State | Runtime | Actively verify task success when no simple pass/fail signal is available | — planned |
@@ -50,10 +50,7 @@ but differs in exactly one complexity factor, enabling causal analysis of agent 
 ```bash
 git clone https://github.com/Mosi-AI/LiveClawBench.git
 cd LiveClawBench
-./setup.sh          # installs harbor CLI, creates .env from template
-
-# Build the shared base image (required once before running any task)
-docker build -t liveclawbench-base:latest docker/base/
+./setup.sh          # installs harbor CLI, builds Docker images, creates .env
 
 # Edit .env with your API key, then run a task:
 source .venv/bin/activate
@@ -63,7 +60,7 @@ harbor run -p tasks/watch-shop -a openclaw -m moonshot/<YOUR_MODEL_ID> \
   --ae CUSTOM_API_KEY="<YOUR_API_KEY>"
 ```
 
-To run all 30 tasks:
+To run all 116 tasks:
 
 ```bash
 harbor run --dataset liveclawbench@0.1.0 -a openclaw \
@@ -95,28 +92,32 @@ See [docs/en/guide/getting-started.md](docs/en/guide/getting-started.md) for ful
 | [Getting Started](docs/en/guide/getting-started.md) | Prerequisites, setup, first run |
 | [Running Tasks](docs/en/guide/running-tasks.md) | Harbor CLI flags, results, full dataset runs |
 | [Adding Tasks](docs/en/guide/adding-tasks.md) | Task format, scoring contract, submission |
-| [Complexity Framework](docs/en/reference/complexity-framework.md) | Factor definitions, 30-case annotation table |
+| [Complexity Framework](docs/en/reference/complexity-framework.md) | Factor definitions, 116-case annotation table |
 | [Task Format](docs/en/reference/task-format.md) | task.toml fields, evaluation rubric |
 
-## Tasks (30 pilot)
+## Tasks (116 validated)
 
 | Domain | Easy | Medium | Hard | Total |
 |--------|------|--------|------|-------|
-| E-commerce & Daily Svcs | 7 | 1 | 3 | 11 |
-| Documents & Knowledge | 6 | 3 | — | 9 |
-| Communication & Email | 2 | — | — | 2 |
-| Calendar & Task Mgmt | 1 | 1 | — | 2 |
-| Coding & Software Dev | 2 | — | — | 2 |
-| DevOps & Env Repair | — | — | 2 | 2 |
-| Deep Research & Report | — | 2 | — | 2 |
-| **Total** | **18** | **7** | **5** | **30** |
+| E-commerce & Daily Svcs | 8 | 7 | 5 | 20 |
+| Documents & Knowledge | 7 | 5 | — | 12 |
+| Deep Research & Report | 1 | 15 | 1 | 17 |
+| DevOps & Env Repair | 2 | 9 | 6 | 17 |
+| Finance & Data Analytics | 3 | 3 | 5 | 11 |
+| Coding & Software Dev | 2 | — | 8 | 10 |
+| Health & Fitness | 4 | 2 | 3 | 9 |
+| Social Media | 2 | 3 | 4 | 9 |
+| Calendar & Task Mgmt | 3 | 3 | 2 | 8 |
+| Communication & Email | 3 | — | — | 3 |
+| **Total** | **35** | **47** | **34** | **116** |
 
-Complexity factors: A1 Cross-Service Dependency (10), A2 Contaminated State (6), B1 Implicit Goals (4), B2 Knowledge Maintenance (11).
+Complexity factors: A1 Cross-Service Dependency (47), A2 Contaminated State (37), B1 Implicit Goals (42), B2 Knowledge Maintenance (26).
 
 ## Leaderboard
 
-Scores are Avg@3: mean of 3 independent runs per task, averaged across 30 tasks, rescaled to [0, 100].
+Scores are Avg@3: mean of 3 independent runs per task, averaged across 30 pilot tasks (v0.1.0), rescaled to [0, 100].
 Evaluated with claw-harbor `v0.1.0` and OpenClaw `2026.3.11`.
+Updated 116-task leaderboard coming soon.
 
 | Model | Avg@3 (0–100) |
 |-------|---------------|
@@ -132,7 +133,7 @@ Evaluated with claw-harbor `v0.1.0` and OpenClaw `2026.3.11`.
 
 - **B1 (Implicit Goal Resolution)** causes -28.7 to -51.3 score degradation across all models
 - **DevOps & Env Repair** is the weakest domain (most models < 15%)
-- **Coding & Software Dev** achieves near-perfect scores on the current 2 routine tasks
+- **Coding & Software Dev** achieves near-perfect scores on routine tasks (v0.1.0 pilot)
 
 Full per-factor and per-domain breakdowns, plus all 630 trajectories → [HuggingFace](https://huggingface.co/datasets/Mosi-AI/LiveClawBench)
 
@@ -157,17 +158,13 @@ LiveClawBench is a living benchmark designed to evolve alongside the OpenClaw ec
 - [x] 30-task pilot benchmark with manual validation (March 2026)
 - [x] Automated evaluation harness for all 30 tasks (March 2026)
 - [x] Public leaderboard with agent trajectories on HuggingFace (April 2026)
-- [ ] Expand to 100+ tasks with broader domain and factor coverage (end of April 2026)
+- [x] Expand to 116 tasks across 10 domains (May 2026)
 - [ ] Community task submission pipeline
 
-### Scale to 100+ Tasks (target: end of April 2026)
+### Future Expansion
 
-Expand from 7 to 15+ domains and add coverage for A3, A4, B3, C1, C2:
+Add coverage for remaining complexity factors:
 
-- [ ] Finance & banking workflows
-- [ ] Healthcare & scheduling scenarios
-- [ ] Travel & logistics (beyond flight booking)
-- [ ] Home & smart device management
 - [ ] A3: Temporal & Resource Constraints (deadline reasoning, rate-limit handling)
 - [ ] A4: Cross-Modal Interaction (images, PDFs, CAPTCHAs — requires vision-capable model)
 - [ ] B3: Multi-Agent Delegation (orchestrator/sub-agent patterns)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -20,7 +20,7 @@ Technical reference for task format and complexity annotations:
 
 | Reference | Description |
 |-----------|-------------|
-| [Complexity Framework](reference/complexity-framework.md) | Factor definitions, 32-case annotation table, domain heatmap, controlled pairs |
+| [Complexity Framework](reference/complexity-framework.md) | Factor definitions, 116-case annotation table, domain heatmap, controlled pairs |
 | [Task Format](reference/task-format.md) | Harbor task directory structure, `task.toml` fields, evaluation rubric |
 | [Jobs Output](reference/jobs-output.md) | `harbor run -o jobs` directory layout, file lifecycle (bind mounts), key fields, troubleshooting |
 

--- a/docs/en/background/assistant_task_complexity.md
+++ b/docs/en/background/assistant_task_complexity.md
@@ -24,7 +24,7 @@ LiveClawBench's design goal: build a benchmark that **systematically measures th
 
 We decompose the complexity of assistant tasks into three orthogonal axes, each containing independently manipulable complexity factors.
 
-> For the complete factor definitions, 32-case annotation table, and statistics, see [Complexity Framework Reference](../reference/complexity-framework.md).
+> For the complete factor definitions, 116-case annotation table, and statistics, see [Complexity Framework Reference](../reference/complexity-framework.md).
 
 ### Axis A: Environment Complexity
 

--- a/docs/en/guide/adding-tasks.md
+++ b/docs/en/guide/adding-tasks.md
@@ -106,7 +106,7 @@ bun run scripts/build-task-images.ts
 docker build -t liveclawbench-{task}:latest tasks/{task}/environment/
 ```
 
-There are four patterns in use across the 32 tasks — pick the one that matches your task type:
+There are four patterns in use across the 116 tasks — pick the one that matches your task type:
 
 ### Pattern 1: Static file drop (skill-\*, blog-site-\*, vue-project-\*)
 
@@ -306,7 +306,7 @@ The validator checks:
 - `case_id` is unique across all tasks
 - Stub warnings: short `instruction.md`, echo-only `test.sh`, missing `solve.sh`
 
-All 42 existing tasks must continue to pass.
+All 116 existing tasks must continue to pass.
 
 ## Submission Checklist
 

--- a/docs/en/guide/running-tasks.md
+++ b/docs/en/guide/running-tasks.md
@@ -250,7 +250,7 @@ harbor run -p tasks/flight-seat-selection -a openclaw \
 
 ## Running the Full Dataset
 
-LiveClawBench registers its 32 tasks as a dataset named `liveclawbench@0.1.0` in the local `registry.json`.
+LiveClawBench registers its 116 tasks as a dataset named `liveclawbench@0.1.0` in the local `registry.json`.
 
 ### Option 1: Local registry (recommended for development)
 
@@ -287,7 +287,7 @@ wait
 
 This avoids the timestamp collision issue entirely because each `harbor run` writes to a distinct `jobs/<task-name>/` directory.
 
-> **Tip:** When using the per-task loop approach, remember to also pass `--ee JUDGE_*` variables for the 5 LLM-judge tasks. See [LLM-judge tasks](#llm-judge-tasks) for the full list and explanation.
+> **Tip:** When using the per-task loop approach, remember to also pass `--ee JUDGE_*` variables for the 20 LLM-judge tasks. See [LLM-judge tasks](#llm-judge-tasks) for the full list and explanation.
 
 ### Option 3: Use the provided script
 
@@ -349,7 +349,7 @@ See [Jobs Output](../reference/jobs-output.md) for the full directory layout and
 
 ## LLM-judge tasks
 
-Five tasks use an LLM-as-judge verifier (`llm_judge.py`) instead of pure rule-based scoring. These tasks require a **separate judge model API** that the verifier calls during the scoring phase — distinct from the model under evaluation.
+Twenty tasks use an LLM-as-judge verifier (`llm_judge.py`) instead of pure rule-based scoring. These tasks require a **separate judge model API** that the verifier calls during the scoring phase — distinct from the model under evaluation.
 
 ### Required environment variables
 
@@ -384,10 +384,25 @@ The judge model can be the same endpoint as the agent model or a different one. 
 | Task | Difficulty |
 |------|-----------|
 | `noise-filtering` | medium |
-| `incremental-update-ctp` | medium |
-| `conflict-repair-acb` | medium |
-| `mixed-tool-memory` | hard |
-| `live-web-research-sqlite-fts5` | hard |
+| `mixed-tool-memory` | easy |
+| `incremental-update-ctp` | easy |
+| `conflict-repair-acb` | easy |
+| `live-web-research-sqlite-fts5` | medium |
+| `pre-meeting-research-brief` | medium |
+| `vendor-due-diligence-brief` | medium |
+| `ai-copyright-international-jurisprudence` | medium |
+| `autonomous-weapons-ethics` | medium |
+| `browser-portal-injection` | easy |
+| `corpus-file-injection` | medium |
+| `crispr-off-target-mitigation` | medium |
+| `cross-border-data-privacy-comparison` | medium |
+| `defi-systemic-risk-contagion` | medium |
+| `digital-religion-ai-vr` | medium |
+| `formal-verification-vs-fuzzing` | medium |
+| `fusion-energy-commercial-viability` | medium |
+| `long-covid-neurological-hypotheses` | medium |
+| `mrna-cancer-vaccines-landscape` | medium |
+| `research-with-adversarial-sources` | hard |
 
 ## Hard Task Tips
 

--- a/mock-platform/README.md
+++ b/mock-platform/README.md
@@ -8,11 +8,22 @@ Bun+Hono mock services that simulate real-world APIs inside task containers. Eac
 mock-platform/
 ├── packages/mock-lib/         # Shared library
 ├── mocks/                     # Per-service implementations
-│   ├── shop/
-│   ├── doc-search/
 │   ├── airline/
+│   ├── calendar/
+│   ├── chat/
+│   ├── doc-search/
 │   ├── email/
-│   └── todolist/
+│   ├── expense/
+│   ├── finance/
+│   ├── health/
+│   ├── insurance/
+│   ├── mint-diet/
+│   ├── shop/
+│   ├── smarthome/
+│   ├── social/
+│   ├── todolist/
+│   ├── weather/
+│   └── workspace/
 ├── scripts/                   # Build & image tools
 ├── config/                    # Task-to-binary mapping
 └── docs/                      # API docs & test references
@@ -44,11 +55,22 @@ Search parity between the legacy Python mock implementations and the current Bun
 
 | Service | Directory | Binary | Description |
 |---------|-----------|--------|-------------|
-| Shop | `mocks/shop/` | `mock-shop` | E-commerce: products, cart, orders, user profile, search |
-| Doc-search | `mocks/doc-search/` | `mock-doc-search` | FTS5 full-text search with BM25 ranking, JSONL access logging |
 | Airline | `mocks/airline/` | `mock-airline` | Flight booking, seat selection, baggage tracking |
+| Calendar | `mocks/calendar/` | `mock-calendar` | Calendar events CRUD with overlap rejection |
+| Chat | `mocks/chat/` | `mock-chat` | Chat messaging with sticker engagement |
+| Doc-search | `mocks/doc-search/` | `mock-doc-search` | FTS5 full-text search with BM25 ranking, JSONL access logging |
 | Email | `mocks/email/` | `mock-email` | Email inbox, compose, reply |
-| Todolist | `mocks/todolist/` | `mock-todolist` | Task management |
+| Expense | `mocks/expense/` | `mock-expense` | Expense tracking and draft management |
+| Finance | `mocks/finance/` | `mock-finance` | Portfolio, invoices, tax, budget, anomaly detection |
+| Health | `mocks/health/` | `mock-health` | Health records, medication tracking, appointments |
+| Insurance | `mocks/insurance/` | `mock-insurance` | Health insurance: claims, appointments, plan selection |
+| Mint-diet | `mocks/mint-diet/` | `mock-mint-diet` | Diet logging, nutrition tracking, snack management |
+| Shop | `mocks/shop/` | `mock-shop` | E-commerce: products, cart, orders, user profile, search |
+| Smarthome | `mocks/smarthome/` | `mock-smarthome` | Smart device management and automation |
+| Social | `mocks/social/` | `mock-social` | Social media posting, scheduling, analytics, moderation |
+| Todolist | `mocks/todolist/` | `mock-todolist` | Task management with date filtering |
+| Weather | `mocks/weather/` | `mock-weather` | Weather reports, AQI, outdoor activity recommendations |
+| Workspace | `mocks/workspace/` | `mock-workspace` | Workspace briefs, task records, batch operations |
 
 API documentation is auto-generated as OpenAPI 3.1 specs in `dist/openapi/*.json`. Run `bun run generate-openapi` to regenerate after route changes.
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 HARBOR_REPO_URL="https://github.com/Mosi-AI/claw-harbor.git"
-HARBOR_VERSION="v0.1.0"
+HARBOR_VERSION="main"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 


### PR DESCRIPTION
## Summary

- Fix all stale task count references across README.md, CLAUDE.md, docs/, and setup.sh (30/32/42 → 116)
- Complete CLAUDE.md Task List from 78 to 116 entries (38 missing tasks were misplaced in Scope table)
- Expand mock-platform/README.md mock services from 5 to 16
- Expand running-tasks.md LLM-judge covered tasks from 5 to 20, with corrected difficulty labels
- Update setup.sh and CLAUDE.md to use claw-harbor `main` branch instead of `v0.1.0`
- Streamline: remove manual docker build from Quick Start, replace CLAUDE.md mock table with summary+link

## Changes by file

| File | Changes |
|------|---------|
| `README.md` | Badge 30→116, status, factor counts (47/37/42/26), task table 10-domain breakdown, roadmap marked complete |
| `CLAUDE.md` | Task List 78→116 rows, LLM judge 17→20, Mock Services → summary+link, harbor → main |
| `setup.sh` | Harbor version v0.1.0 → main |
| `docs/en/README.md` | 32-case → 116-case |
| `docs/en/guide/running-tasks.md` | Dataset count 32→116, LLM-judge 5→20 with full table |
| `docs/en/guide/adding-tasks.md` | 32→116, 42→116 |
| `docs/en/background/assistant_task_complexity.md` | 32-case → 116-case |
| `mock-platform/README.md` | Architecture tree + service table 5→16 mocks |

## Test plan

- [ ] `grep -rn "30 pilot\|30 tasks\|32 tasks\|32-case\|42 existing" README.md CLAUDE.md docs/ mock-platform/README.md` returns only intentional references (pilot leaderboard, historical roadmap)
- [ ] CLAUDE.md Task List has exactly 116 rows: `awk '/^## Task List/,/^## Docker/' CLAUDE.md | grep "^| \`" | wc -l`
- [ ] mock-platform/README.md has 16 mock services in table
- [ ] running-tasks.md Covered Tasks table has 20 entries