### PR TITLE
Bump LiveClawBench and claw-harbor to 0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ source .venv/bin/activate
 ```bash
 uv venv .venv
 source .venv/bin/activate
-uv pip install "harbor @ git+https://github.com/Mosi-AI/claw-harbor.git@main"
+uv pip install "harbor @ git+https://github.com/Mosi-AI/claw-harbor.git@0.2.0"
 ```
 
 ### API Key Configuration
@@ -114,7 +114,7 @@ harbor run -p tasks/watch-shop -a openclaw \
 
 ```bash
 # Generic form (includes LLM judge credentials for the 7 judge tasks)
-harbor run --dataset liveclawbench@0.1.0 -a openclaw \
+harbor run --dataset liveclawbench@0.2.0 -a openclaw \
   -m custom/<YOUR_MODEL_ID> \
   --n-concurrent 4 \
   -o jobs \
@@ -124,7 +124,7 @@ harbor run --dataset liveclawbench@0.1.0 -a openclaw \
   --ee JUDGE_API_KEY="<JUDGE_API_KEY>"
 
 # Example: Anthropic
-harbor run --dataset liveclawbench@0.1.0 -a openclaw \
+harbor run --dataset liveclawbench@0.2.0 -a openclaw \
   -m anthropic/claude-opus-4-1 \
   --n-concurrent 4 \
   --ae ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ harbor run -p tasks/watch-shop -a openclaw -m moonshot/<YOUR_MODEL_ID> \
 To run all 134 tasks:
 
 ```bash
-harbor run --dataset liveclawbench@0.1.0 -a openclaw \
+harbor run --dataset liveclawbench@0.2.0 -a openclaw \
   -m moonshot/<YOUR_MODEL_ID> --n-concurrent 4 -o jobs \
   --ae CUSTOM_BASE_URL="<YOUR_BASE_URL>" \
   --ae CUSTOM_API_KEY="<YOUR_API_KEY>" \

--- a/docs/en/guide/running-tasks.md
+++ b/docs/en/guide/running-tasks.md
@@ -250,12 +250,12 @@ harbor run -p tasks/flight-seat-selection -a openclaw \
 
 ## Running the Full Dataset
 
-LiveClawBench registers its 134 tasks as a dataset named `liveclawbench@0.1.0` in the local `registry.json`.
+LiveClawBench registers its 134 tasks as a dataset named `liveclawbench@0.2.0` in the local `registry.json`.
 
 ### Option 1: Local registry (recommended for development)
 
 ```bash
-harbor run --dataset liveclawbench@0.1.0 \
+harbor run --dataset liveclawbench@0.2.0 \
   --registry-path ./registry.json \
   -a openclaw \
   -m custom/<YOUR_MODEL_ID> \

--- a/docs/zh/guide/running-tasks.md
+++ b/docs/zh/guide/running-tasks.md
@@ -250,12 +250,12 @@ harbor run -p tasks/flight-seat-selection -a openclaw \
 
 ## 运行完整数据集
 
-LiveClawBench 在本地 `registry.json` 中将 134 个任务注册为数据集 `liveclawbench@0.1.0`。
+LiveClawBench 在本地 `registry.json` 中将 134 个任务注册为数据集 `liveclawbench@0.2.0`。
 
 ### 方案一：本地 registry（推荐用于开发）
 
 ```bash
-harbor run --dataset liveclawbench@0.1.0 \
+harbor run --dataset liveclawbench@0.2.0 \
   --registry-path ./registry.json \
   -a openclaw \
   -m custom/<YOUR_MODEL_ID> \

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "liveclawbench",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "LiveClawBench: Benchmarking LLM Agents on Complex, Real-World Assistant Tasks. 134 tasks with 4 complexity factors (A1/A2/B1/B2) across 10 task domains.",
     "tasks": [
       {

--- a/scripts/extract_hf_parity.py
+++ b/scripts/extract_hf_parity.py
@@ -231,6 +231,7 @@ def main():
         records = df.to_dict("records")
     else:
         print("Loading HuggingFace dataset...")
+        # TODO: update split to "v0.2.0" once the HuggingFace dataset is published
         ds = load_dataset("Mosi-AI/LiveClawBench", split="v0.1.0")
         print(f"Total records: {len(ds)}")
         airline_ds = ds.filter(lambda x: x["case_name"] in AIRLINE_TASKS)

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 HARBOR_REPO_URL="https://github.com/Mosi-AI/claw-harbor.git"
-HARBOR_VERSION="main"
+HARBOR_VERSION="0.2.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 


### PR DESCRIPTION
## Summary

- Bump LiveClawBench dataset version from `0.1.0` to `0.2.0`
- Pin claw-harbor dependency from `main` branch to `0.2.0` tag

## Changes

| File | Change |
|------|--------|
| `registry.json` | Dataset version `0.1.0` → `0.2.0` |
| `setup.sh` | `HARBOR_VERSION="main"` → `"0.2.0"` |
| `CLAUDE.md` | Update manual install URL and dataset references |
| `README.md` | Update dataset reference in quick-start |
| `docs/en/guide/running-tasks.md` | Update dataset references |
| `docs/zh/guide/running-tasks.md` | Update dataset references |