### PR TITLE
fix(flight): move inject_data.py from build-time to runtime

### DIFF
--- a/tasks/baggage-tracking-application/environment/Dockerfile
+++ b/tasks/baggage-tracking-application/environment/Dockerfile
@@ -6,8 +6,8 @@ COPY . /workspace/environment/
 # Install airline-app backend dependencies
 RUN cd /workspace/environment/airline-app/backend && pip install --break-system-packages -r requirements.txt
 
-# Inject pre-defined data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # NODE_ENV=production is set by the base openclaw image, which causes npm install to
 # skip devDependencies (including vite). --include=dev forces them to be installed.

--- a/tasks/baggage-tracking-application/environment/Dockerfile
+++ b/tasks/baggage-tracking-application/environment/Dockerfile
@@ -6,8 +6,9 @@ COPY . /workspace/environment/
 # Install airline-app backend dependencies
 RUN cd /workspace/environment/airline-app/backend && pip install --break-system-packages -r requirements.txt
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # NODE_ENV=production is set by the base openclaw image, which causes npm install to
 # skip devDependencies (including vite). --include=dev forces them to be installed.

--- a/tasks/flight-booking/environment/Dockerfile
+++ b/tasks/flight-booking/environment/Dockerfile
@@ -6,8 +6,8 @@ COPY . /workspace/environment/
 # Install airline-app backend dependencies
 RUN cd /workspace/environment/airline-app/backend && pip install --break-system-packages -r requirements.txt
 
-# Inject pre-defined data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log

--- a/tasks/flight-booking/environment/Dockerfile
+++ b/tasks/flight-booking/environment/Dockerfile
@@ -6,8 +6,9 @@ COPY . /workspace/environment/
 # Install airline-app backend dependencies
 RUN cd /workspace/environment/airline-app/backend && pip install --break-system-packages -r requirements.txt
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log

--- a/tasks/flight-cancel-claim/environment/Dockerfile
+++ b/tasks/flight-cancel-claim/environment/Dockerfile
@@ -9,8 +9,8 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# Inject pre-defined data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-cancel-claim/environment/Dockerfile
+++ b/tasks/flight-cancel-claim/environment/Dockerfile
@@ -9,8 +9,9 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-info-change-notice/environment/Dockerfile
+++ b/tasks/flight-info-change-notice/environment/Dockerfile
@@ -9,8 +9,8 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# Inject initial data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py || true
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-info-change-notice/environment/Dockerfile
+++ b/tasks/flight-info-change-notice/environment/Dockerfile
@@ -9,8 +9,9 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-seat-selection-failed/environment/Dockerfile
+++ b/tasks/flight-seat-selection-failed/environment/Dockerfile
@@ -9,8 +9,8 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# Inject pre-defined data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-seat-selection-failed/environment/Dockerfile
+++ b/tasks/flight-seat-selection-failed/environment/Dockerfile
@@ -9,8 +9,9 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-seat-selection/environment/Dockerfile
+++ b/tasks/flight-seat-selection/environment/Dockerfile
@@ -9,8 +9,8 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# Inject pre-defined data
-RUN cd /workspace/environment/airline-app/backend && python3 scripts/inject_data.py
+# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
+#  be computed at container start, not at image build. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths

--- a/tasks/flight-seat-selection/environment/Dockerfile
+++ b/tasks/flight-seat-selection/environment/Dockerfile
@@ -9,8 +9,9 @@ RUN cd /workspace/environment/airline-app/backend && pip install --break-system-
 # Install airline-app frontend dependencies
 RUN cd /workspace/environment/airline-app/frontend && npm install --include=dev 2>&1 | tee /tmp/airline-npm-install.log
 
-# (inject_data.py moved to startup.sh — datetime.now()-relative seeds must
-#  be computed at container start, not at image build. Issue #108 §2.1)
+# (inject_data.py removed from build-time — runtime seeding is handled
+#  by the mock-airline binary's seedDatabase() with datetime.now()-relative
+#  dates. See mock-platform/mocks/airline/src/seed.ts. Issue #108 §2.1)
 
 # Install Playwright Chromium and symlink to /usr/bin/chromium so openclaw's
 # findChromeExecutableLinux() can detect it. openclaw only checks system paths


### PR DESCRIPTION
# Flight `inject_data.py` build-time → runtime

## 背景

6 个 flight 任务的 `Dockerfile` 在 build 阶段 `RUN python3 inject_data.py`——`inject_data.py` 内部用 `datetime.now()` 计算 "next Monday" 等动态日期写入 seed 数据。

结果：**镜像 build 当天的 "next Monday" 被钉死在镜像里**。任务实际跑的当天可能已经是另一周——verifier 找不到匹配的 next-Monday 航班，agent 不管做什么都 0 分。

GitHub issue：#108 §2.1。

## 改动范围（6 文件，纯 Dockerfile RUN 移除）

| 任务 | Dockerfile 改动 |
|---|---|
| `flight-booking` | 移除 `RUN cd .../airline-app/backend && python3 scripts/inject_data.py` |
| `flight-cancel-claim` | 同上 |
| `flight-info-change-notice` | 同上 |
| `flight-seat-selection` | 同上 |
| `flight-seat-selection-failed` | 同上 |
| `baggage-tracking-application` | 同上 |

`git diff --stat upstream/main..HEAD`：**6 files / +12 -12**。

## 真实运行机制

```
container 启动
  ↓
shared/entrypoint.sh
  ↓
/opt/mock/startup.d/${TASK_NAME}.sh        ← build-task-images.ts 生成（read-only）
                                              ↑ 这才是真正执行的 startup
  ↓
读 mock-platform/config/task-binary-map.json["flight-booking"].binaries = ["airline"]
  ↓
emit "airline" 分支（build-task-images.ts:559-585）：
  • export AIRLINE_DB_PATH=/var/lib/mock-data/airline/airline.db
  • ln -sfn /opt/mock/python_compat/airline-app /workspace/environment/airline-app
    （Flask airline-app 被替换成 python_compat 桥；verifier 的 SQLAlchemy
     import 会落到 Bun-backed 共享 DB）
  • 启动 /opt/mock/bin/mock-airline → Bun 进程
  ↓
Bun mock-airline 启动时 seedDatabase()
  （mock-platform/mocks/airline/src/seed.ts:57-63 — nextMonday() 用 new Date()
   实时计算）
  ↓
写 /var/lib/mock-data/airline/airline.db，含当天起算的 next Monday 数据
```

**关键点**：`tasks/<flight-task>/environment/startup.sh` **不参与上述链路**——entrypoint 不读 `/workspace/` 里的 startup，只读 `/opt/mock/startup.d/` 这条只读路径（出于安全：`/workspace/` 是 agent 可写的）。

## 早期版本的错误（已 amend 修正）

`d51f3402`（旧 HEAD）除了改 6 个 Dockerfile，还往 6 个 `tasks/<task>/environment/startup.sh` 加了 11 行 inject 调用——这些**永远不会被执行**，是 dead code。

reviewer @mockiemochi 直接指出此 bug：
> All 6 startup.sh additions are dead code — the PR's mechanism doesn't execute at runtime. The container entrypoint invokes `/opt/mock/startup.d/${TASK_NAME}.sh` (a generated script), not `tasks/{task}/environment/startup.sh`.

**当前 HEAD `f29ee652`** 已把 6 个 startup.sh **完全 revert 到 upstream/main 状态**，PR 范围窄化到只有 6 个 Dockerfile 修改。

### 为什么 Dockerfile RUN 移除单独就够？

去掉 `RUN python3 inject_data.py` 后，镜像里就不再有 build-time 钉死的 stale seed。等容器启动时，**Bun mock-airline 的 `seedDatabase()` 用 `new Date()` 实时计算 next Monday 并写入共享 DB**——这是已经存在的运行时机制，PR-3 不需要新增任何 startup 逻辑去触发它。

## 验证证据（n=1，model=`moonshot/deepseek-v4-pro-guan`）

来自 `pr_audit/results/pr3/diff.tsv`（注：当时跑的是 `d51f3402` 含 dead-code startup.sh 的版本，但因 startup.sh 不被执行，结果与新 `f29ee652` 完全等价）：

| task | before | after | Δ | 评价 |
|---|---|---|---|---|
| `flight-seat-selection` | 0.00 | **1.00** | **+1.00** | ✅ **直接证据**：Dockerfile 移除 RUN 后，Bun mock-airline 启动时 seed 的 next-Monday 航班存在 |
| `baggage-tracking-application` | 1.00 | 1.00 | 0 | ✅ 一直就过（baggage 不严格依赖 next-Monday） |
| `flight-booking` | 0.00 | 0.00 | 0 | ⚠️ 仍 0——其他缺陷（peter 凭证 / 前端崩溃 / verifier 锁定 peter），**L4，不在 PR-3 范围** |
| `flight-cancel-claim` | 0.00 | 0.00 | 0 | ⚠️ 同上（隐藏收件人 `claims@gkdairlines.com`，L4） |
| `flight-info-change-notice` | 0.00 | 0.00 | 0 | ⚠️ 同上 |
| `flight-seat-selection-failed` | 0.00 | 0.00 | 0 | ⚠️ 同上 |

**mean Δ = +0.1667**。

### `flight-seat-selection` 0→1 解读

PR-3 设计的最直接证据：

- BEFORE：image build 时钉死的 next-Monday 日期已过期，verifier 查 next-Monday 航班，DB 里没有匹配 → 0
- AFTER：build-time 不再 seed；Bun mock-airline 启动时 `seedDatabase()` 用容器启动当天计算 next-Monday → 匹配 → 1.0

其他 4 个 flight 任务仍 0 是 **L4 instruction-verifier 失配**（FIX_PLAN PR-6 处理），与 PR-3 设计无关。
