### PR TITLE
fix(setup): add missing 'v' prefix to HARBOR_VERSION tag

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 HARBOR_REPO_URL="https://github.com/Mosi-AI/claw-harbor.git"
-HARBOR_VERSION="0.2.0"
+HARBOR_VERSION="v0.2.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 


### PR DESCRIPTION
## Summary

HARBOR_VERSION in setup.sh was set to "v0.2.0"