### PR TITLE
fix(skill-*): normalize reward.json to harbor schema (issue #110 B1)

### DIFF
--- a/tasks/skill-combination/tests/normalize_reward.py
+++ b/tasks/skill-combination/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-combination/tests/test.sh
+++ b/tasks/skill-combination/tests/test.sh
@@ -14,6 +14,10 @@ SCORE=$(grep -oP 'TOTAL:\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "0")
 MAX=$(grep -oP 'TOTAL:\s*[0-9]+\s*/\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "85")
 python3 -c "print(${SCORE}/${MAX})" > /logs/verifier/reward.txt
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-combination/tests/test_normalize_reward.py
+++ b/tasks/skill-combination/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out

--- a/tasks/skill-conflict-resolution/tests/normalize_reward.py
+++ b/tasks/skill-conflict-resolution/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-conflict-resolution/tests/test.sh
+++ b/tasks/skill-conflict-resolution/tests/test.sh
@@ -16,6 +16,10 @@ SCORE=$(grep -oP 'TOTAL:\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "0")
 MAX=$(grep -oP 'TOTAL:\s*[0-9]+\s*/\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "1")
 python3 -c "print(${SCORE}/${MAX})" > /logs/verifier/reward.txt
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-conflict-resolution/tests/test_normalize_reward.py
+++ b/tasks/skill-conflict-resolution/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out

--- a/tasks/skill-creation/tests/normalize_reward.py
+++ b/tasks/skill-creation/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-creation/tests/test.sh
+++ b/tasks/skill-creation/tests/test.sh
@@ -14,6 +14,10 @@ else
     echo "0.0" > /logs/verifier/reward.txt
 fi
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-creation/tests/test_normalize_reward.py
+++ b/tasks/skill-creation/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out

--- a/tasks/skill-dependency-fix/tests/normalize_reward.py
+++ b/tasks/skill-dependency-fix/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-dependency-fix/tests/test.sh
+++ b/tasks/skill-dependency-fix/tests/test.sh
@@ -16,6 +16,10 @@ python3 /tests/evaluate.py \
 SCORE=$(grep -oP 'TOTAL SCORE:\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "0")
 python3 -c "print(${SCORE}/100.0)" > /logs/verifier/reward.txt
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-dependency-fix/tests/test_normalize_reward.py
+++ b/tasks/skill-dependency-fix/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out

--- a/tasks/skill-repository-curation/tests/normalize_reward.py
+++ b/tasks/skill-repository-curation/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-repository-curation/tests/test.sh
+++ b/tasks/skill-repository-curation/tests/test.sh
@@ -76,6 +76,10 @@ python3 /tests/evaluate.py \
 SCORE=$(grep -oP 'TOTAL SCORE:\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "0")
 python3 -c "print(${SCORE}/100.0)" > /logs/verifier/reward.txt
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-repository-curation/tests/test_normalize_reward.py
+++ b/tasks/skill-repository-curation/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out

--- a/tasks/skill-supplementation/tests/normalize_reward.py
+++ b/tasks/skill-supplementation/tests/normalize_reward.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Normalize a skill-* task's eval_result.json into a harbor-compliant reward.json.
+
+Harbor's VerifierResult model enforces ``rewards: dict[str, float | int]``
+on the top level of /logs/verifier/reward.json. Any non-numeric top-level
+field must be prefixed with ``_meta_``, otherwise harbor raises a Pydantic
+ValidationError when it parses the reward file. See
+docs/en/guide/adding-tasks.md → "`reward.json` rules" (issue #110, B1).
+
+This helper:
+
+1. Reads the verbose ``eval_result.json`` written by evaluate.py.
+2. Computes the canonical ``reward`` scalar (float in [0.0, 1.0]) as
+   ``total_score / max_score`` (or uses ``--reward`` when the caller
+   already derived it from stdout, e.g. via a ``TOTAL:`` line).
+3. Rewrites every top-level key so the output is schema-compliant:
+
+   - ``reward`` is added/overridden with the float scalar.
+   - Numeric (int/float/bool) keys are passed through unchanged.
+   - Every other key is renamed with a ``_meta_`` prefix and the value is
+     serialised as a JSON string (so nested objects / arrays / strings
+     are all schema-legal under ``dict[str, float | int]`` — they live
+     under keys harbor explicitly ignores).
+
+4. Writes the result to the requested output path.
+
+Used by tasks/skill-*/tests/test.sh in place of a raw
+``cp eval_result.json reward.json`` which produces a schema-violating
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _coerce_reward(data: dict[str, Any], explicit: float | None) -> float:
+    """Pick the canonical reward scalar."""
+    if explicit is not None:
+        return max(0.0, min(1.0, float(explicit)))
+    total = data.get("total_score")
+    maximum = data.get("max_score")
+    if (
+        isinstance(total, (int, float))
+        and isinstance(maximum, (int, float))
+        and maximum
+    ):
+        return max(0.0, min(1.0, float(total) / float(maximum)))
+    # passed-style scoring (skill-creation).
+    passed = data.get("passed")
+    if isinstance(passed, bool):
+        return 1.0 if passed else 0.0
+    return 0.0
+
+
+def normalize(data: dict[str, Any], reward: float | None = None) -> dict[str, Any]:
+    """Return a schema-compliant copy of ``data`` for /logs/verifier/reward.json.
+
+    Top-level guarantees:
+      * ``reward`` is present and is a ``float``.
+      * Every other top-level key is either a number (int/float/bool) or
+        has the ``_meta_`` prefix with a string value.
+    """
+    out: dict[str, Any] = {}
+    out["reward"] = float(_coerce_reward(data, reward))
+
+    for key, value in data.items():
+        if key == "reward":
+            # already handled above; ignore any conflicting source value.
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            # Numeric scalar — safe to keep as-is.
+            out[key] = value
+            continue
+        meta_key = key if key.startswith("_meta_") else f"_meta_{key}"
+        if isinstance(value, str):
+            out[meta_key] = value
+        else:
+            # nested dict/list/None/etc → JSON-serialise to a string.
+            out[meta_key] = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return out
+
+
+def _load(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    obj = json.loads(raw)
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(obj).__name__}")
+    return obj
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize eval_result.json into a harbor-compliant reward.json "
+            "(see issue #110 B1 / docs/en/guide/adding-tasks.md)."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Path to eval_result.json")
+    parser.add_argument("--output", required=True, help="Path to write reward.json")
+    parser.add_argument(
+        "--reward",
+        type=float,
+        default=None,
+        help=(
+            "Optional canonical reward scalar (float in [0,1]). When omitted, "
+            "derived from total_score/max_score or `passed` in the input."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.input)
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not in_path.exists():
+        # eval_result.json wasn't produced (e.g. evaluate.py crashed before
+        # writing it). Still write a schema-compliant reward.json so harbor
+        # doesn't fail with ValidationError on the missing file.
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"eval_result.json not generated at {in_path}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(
+            f"normalize_reward: input missing ({in_path}); wrote fallback reward.json",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        data = _load(in_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        fallback = {
+            "reward": float(args.reward) if args.reward is not None else 0.0,
+            "_meta_error": f"failed to parse {in_path}: {exc}",
+        }
+        out_path.write_text(json.dumps(fallback, indent=2, ensure_ascii=False))
+        print(f"normalize_reward: parse error: {exc}", file=sys.stderr)
+        return 0
+
+    normalized = normalize(data, args.reward)
+    out_path.write_text(json.dumps(normalized, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tasks/skill-supplementation/tests/test.sh
+++ b/tasks/skill-supplementation/tests/test.sh
@@ -16,6 +16,10 @@ SCORE=$(grep -oP 'TOTAL:\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "0")
 MAX=$(grep -oP 'TOTAL:\s*[0-9]+\s*/\s*\K[0-9]+' /tmp/eval_output.txt | head -1 || echo "1")
 python3 -c "print(${SCORE}/${MAX})" > /logs/verifier/reward.txt
 
-# reward.json: detailed per-criterion breakdown
-cp /workspace/output/eval_result.json /logs/verifier/reward.json 2>/dev/null || \
-    echo '{"error":"eval_result.json not generated"}' > /logs/verifier/reward.json
+# reward.json: harbor-compliant schema ({reward: float, _meta_*: ...}).
+# Issue #110 (B1): raw `cp eval_result.json reward.json` violates harbor's
+# VerifierResult schema (top-level non-float keys without `_meta_` prefix).
+python3 /tests/normalize_reward.py \
+    --input /workspace/output/eval_result.json \
+    --output /logs/verifier/reward.json \
+    --reward "$(cat /logs/verifier/reward.txt)"

--- a/tasks/skill-supplementation/tests/test_normalize_reward.py
+++ b/tasks/skill-supplementation/tests/test_normalize_reward.py
@@ -1,0 +1,201 @@
+"""Acceptance test for issue #110 B1 — reward.json schema compliance.
+
+The original test.sh ran ``cp eval_result.json reward.json`` which left
+top-level non-float keys (``case``, ``task``, ``criteria``, ...) in the
+output, violating harbor's VerifierResult schema (``rewards: dict[str,
+float | int]``). normalize_reward.py is the fix: it must produce a JSON
+object where every top-level key is either ``reward`` (the canonical
+float scalar), another number, or has the ``_meta_`` prefix.
+
+These tests load the task-local normalize_reward.py via importlib so each
+task's copy is exercised independently (per the tracking issue's
+"each PR independently complete" principle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+TASK_NAME = HERE.parent.name
+
+
+def _load_normalizer():
+    spec = importlib.util.spec_from_file_location(
+        f"{TASK_NAME}.normalize_reward",
+        HERE / "normalize_reward.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE_EVAL_RESULT = {
+    "case": "sh_skill_combination",
+    "task": "SKILL_COMBINATION",
+    "max_score": 85,
+    "total_score": 40,
+    "criteria": {
+        "COMPOSITE_SKILL_CREATED": {
+            "score": 20,
+            "details": {"skill_path": "/workspace/SKILL.md", "passed": True},
+        },
+        "CORRECT_SKILLS_SELECTED": {"score": 20, "details": {"reason": "ok"}},
+    },
+}
+
+
+def _assert_schema_compliant(obj: dict) -> None:
+    """Mirror harbor's VerifierResult constraint.
+
+    `reward` must exist and be a float. Every other top-level key must
+    either hold a number (int/float/bool) or carry the ``_meta_`` prefix.
+    """
+    assert "reward" in obj, "reward key missing"
+    assert isinstance(obj["reward"], float), (
+        f"reward must be float, got {type(obj['reward']).__name__}"
+    )
+    assert 0.0 <= obj["reward"] <= 1.0, f"reward out of range: {obj['reward']}"
+    for key, value in obj.items():
+        if key == "reward":
+            continue
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            continue
+        assert key.startswith("_meta_"), (
+            f"non-numeric top-level key {key!r} must be prefixed with '_meta_' "
+            f"(value type: {type(value).__name__})"
+        )
+
+
+def test_normalize_produces_reward_float():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=40 / 85)
+    assert isinstance(out["reward"], float)
+    assert abs(out["reward"] - 40 / 85) < 1e-9
+
+
+def test_normalize_moves_strings_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    # The string-valued `case` and `task` keys must not survive at the top
+    # level — they must be renamed to _meta_case / _meta_task so harbor's
+    # rewards dict only contains numbers.
+    assert "case" not in out
+    assert "task" not in out
+    assert out.get("_meta_case") == "sh_skill_combination"
+    assert out.get("_meta_task") == "SKILL_COMBINATION"
+
+
+def test_normalize_moves_nested_dict_under_meta_prefix():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert "criteria" not in out
+    assert "_meta_criteria" in out
+    nested = json.loads(out["_meta_criteria"])
+    assert "COMPOSITE_SKILL_CREATED" in nested
+
+
+def test_normalize_preserves_numeric_keys():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.5)
+    assert out.get("total_score") == 40
+    assert out.get("max_score") == 85
+
+
+def test_normalize_full_output_is_schema_compliant():
+    mod = _load_normalizer()
+    out = mod.normalize(SAMPLE_EVAL_RESULT, reward=0.47)
+    _assert_schema_compliant(out)
+
+
+def test_normalize_handles_passed_style_input():
+    """skill-creation's evaluate.py writes {"passed": bool} instead of totals."""
+    mod = _load_normalizer()
+    payload = {
+        "case": "sh_case1",
+        "task": "SKILL_CREATION",
+        "passed": True,
+        "detail": "/workspace/SKILL.md",
+    }
+    out = mod.normalize(payload, reward=None)
+    assert out["reward"] == 1.0
+    _assert_schema_compliant(out)
+    payload["passed"] = False
+    out2 = mod.normalize(payload, reward=None)
+    assert out2["reward"] == 0.0
+
+
+def test_cli_writes_compliant_file(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text(json.dumps(SAMPLE_EVAL_RESULT))
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.47"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+
+
+def test_cli_writes_fallback_when_input_missing(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "missing.json"
+    out = tmp_path / "reward.json"
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert obj["reward"] == 0.0
+    assert "_meta_error" in obj
+
+
+def test_cli_writes_fallback_when_input_corrupt(tmp_path):
+    mod = _load_normalizer()
+    inp = tmp_path / "eval_result.json"
+    out = tmp_path / "reward.json"
+    inp.write_text("not valid json {")
+    rc = mod.main(["--input", str(inp), "--output", str(out), "--reward", "0.0"])
+    assert rc == 0
+    obj = json.loads(out.read_text())
+    _assert_schema_compliant(obj)
+    assert "_meta_error" in obj
+
+
+def test_test_sh_does_not_use_raw_cp_for_reward_json():
+    """Regression guard for the original B1 bug.
+
+    The fix must NOT regress to a plain ``cp eval_result.json
+    /logs/verifier/reward.json`` because that produces a schema-violating
+    file.
+    """
+    test_sh = HERE / "test.sh"
+    body = test_sh.read_text(encoding="utf-8")
+    bad = "cp /workspace/output/eval_result.json /logs/verifier/reward.json"
+    assert bad not in body, (
+        f"{test_sh} still uses the raw `cp eval_result.json reward.json` "
+        f"that issue #110 B1 banned"
+    )
+    assert "normalize_reward.py" in body, (
+        f"{test_sh} does not invoke normalize_reward.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        SAMPLE_EVAL_RESULT,
+        {"passed": False, "detail": "fail"},
+        {"total_score": 100, "max_score": 100, "criteria": {}, "case": "x"},
+    ],
+)
+def test_normalize_outputs_are_jsonable(raw):
+    mod = _load_normalizer()
+    out = mod.normalize(raw, reward=None)
+    serialised = json.dumps(out)
+    assert json.loads(serialised) == out


### PR DESCRIPTION
## Summary

Fixes the **B1** bug from #110: the 6 `skill-*` tasks write a schema-violating `reward.json` that causes harbor `ValidationError`.

### Problem

Each `skill-*` task's `test.sh` did a raw `cp eval_result.json reward.json`, which copies the verbose evaluation output (containing non-numeric top-level keys like `"details"`, `"errors"`, etc.) directly into the reward file. Harbor's `VerifierResult` model requires:

- A top-level `reward` key with a `float` value
- All non-numeric top-level keys must be prefixed with `_meta_`

When the schema is violated, harbor raises a `Pydantic ValidationError` and the task gets an incorrect zero score.

### Fix

For each of the 6 affected tasks:
- **skill-creation**
- **skill-supplementation**
- **skill-repository-curation**
- **skill-dependency-fix**
- **skill-combination**
- **skill-conflict-resolution**

1. Added `tests/normalize_reward.py` — a self-contained Python helper that:
   - Reads `eval_result.json`
   - Computes the canonical `reward` scalar (`total_score / max_score`, `passed` bool, or explicit `--reward`)
   - Renames all non-numeric top-level keys with `_meta_` prefix
   - Writes a schema-compliant `reward.json`
   - Handles missing/malformed input gracefully with a fallback

2. Updated `tests/test.sh` to call `normalize_reward.py` instead of the raw `cp`

3. Added `tests/test_normalize_reward.py` — pytest tests for each task's normalize helper

### Design decisions

- `normalize_reward.py` is **duplicated** into each task's `tests/` directory (not centralized under `shared/`) so each PR is self-contained, per the tracking issue's "each PR must be independently complete" principle.
- The helper gracefully handles missing/malformed `eval_result.json` by writing a fallback `reward.json` with `_meta_error` instead of crashing.

### Verification

- ✅ 6 acceptance tests (one per task): all pass (before: fail → after: pass)
- ✅ Regression: 4 existing verifier tests pass, 0 new failures
- ✅ 18 files changed, 2160 insertions, 18 deletions

Covers issue #110 PR-1 / B1.